### PR TITLE
Adding Response format for GET /libraries/sections [getLibraries]

### DIFF
--- a/plex-media-server-spec-dereferenced.yaml
+++ b/plex-media-server-spec-dereferenced.yaml
@@ -1479,6 +1479,74 @@ paths:
       responses:
         '200':
           description: The libraries available on the Server
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  MediaContainer:
+                    type: object
+                    properties:
+                      size:
+                        type: number
+                      allowSync:
+                        type: boolean
+                      title1:
+                        type: string
+                      Directory:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            allowSync:
+                              type: boolean
+                            art:
+                              type: string
+                            composite:
+                              type: string
+                            filters:
+                              type: boolean
+                            refreshing:
+                              type: boolean
+                            thumb:
+                              type: string
+                            key:
+                              type: string
+                            type:
+                              type: string
+                            title:
+                              type: string
+                            agent:
+                              type: string
+                            scanner:
+                              type: string
+                            language:
+                              type: string
+                            uuid:
+                              type: string
+                            updatedAt:
+                              type: number
+                            createdAt:
+                              type: number
+                            scannedAt:
+                              type: number
+                            content:
+                              type: boolean
+                            directory:
+                              type: boolean
+                            contentChangedAt:
+                              type: number
+                            hidden:
+                              type: number
+                            Location:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  id:
+                                    type: number
+                                  path:
+                                    type: string
         '400':
           description: 'Bad Request - A parameter was not specified, or was specified incorrectly.'
         '401':

--- a/pms/paths/libraries.yaml
+++ b/pms/paths/libraries.yaml
@@ -22,65 +22,125 @@ get:
                 type: object
                 properties:
                   size:
-                    type: number
+                    type: integer
+                    format: int32
+                    example: 5
                   allowSync:
                     type: boolean
+                    example: false
                   title1:
                     type: string
+                    example: Plex Library
                   Directory:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        allowSync:
-                          type: boolean
-                        art:
-                          type: string
-                        composite:
-                          type: string
-                        filters:
-                          type: boolean
-                        refreshing:
-                          type: boolean
-                        thumb:
-                          type: string
-                        key:
-                          type: string
-                        type:
-                          type: string
-                        title:
-                          type: string
-                        agent:
-                          type: string
-                        scanner:
-                          type: string
-                        language:
-                          type: string
-                        uuid:
-                          type: string
-                        updatedAt:
-                          type: number
-                        createdAt:
-                          type: number
-                        scannedAt:
-                          type: number
-                        content:
-                          type: boolean
-                        directory:
-                          type: boolean
-                        contentChangedAt:
-                          type: number
-                        hidden:
-                          type: number
+                      - type: object
+                        properties:
+                          allowSync:
+                            type: boolean
+                            example: true
+                          art:
+                            type: string
+                            example: /:/resources/movie-fanart.jpg
+                          composite:
+                            type: string
+                            example: /library/sections/1/composite/1705615584
+                          filters:
+                            type: boolean
+                            example: true
+                          refreshing:
+                            type: boolean
+                            example: false
+                          thumb:
+                            type: string
+                            example: /:/resources/movie.png
+                          key:
+                            type: string
+                            example: "1"
+                          type:
+                            type: string
+                            example: movie
+                          title:
+                            type: string
+                            example: Movies
+                          agent:
+                            type: string
+                            example: tv.plex.agents.movie
+                          scanner:
+                            type: string
+                            example: Plex Movie
+                          language:
+                            type: string
+                            example: en-US
+                          uuid:
+                            type: string
+                            example: 322a231a-b7f7-49f5-920f-14c61199cd30
+                          updatedAt:
+                            type: integer
+                            format: int32
+                            example: 1705615634
+                          createdAt:
+                            type: integer
+                            format: int32
+                            example: 1654131312
+                          scannedAt:
+                            type: integer
+                            format: int32
+                            example: 1705615584
+                          content:
+                            type: boolean
+                            example: true
+                          directory:
+                            type: boolean
+                            example: true
+                          contentChangedAt:
+                            type: integer
+                            format: int32
+                            example: 3192854
+                          hidden:
+                            type: integer
+                            format: int32
+                            example: 0
+                          Location:
+                            type: array
+                            items:
+                              - type: object
+                                properties:
+                                  id:
+                                    type: integer
+                                    format: int32
+                                    example: 1
+                                  path:
+                                    type: string
+                                    example: /movies
+                            example:
+                              - id: 1
+                                path: /movies
+                    example:
+                      - allowSync: true
+                        art: /:/resources/movie-fanart.jpg
+                        composite: /library/sections/1/composite/1705615584
+                        filters: true
+                        refreshing: false
+                        thumb: /:/resources/movie.png
+                        key: "1"
+                        type: movie
+                        title: Movies
+                        agent: tv.plex.agents.movie
+                        scanner: Plex Movie
+                        language: en-US
+                        uuid: 322a231a-b7f7-49f5-920f-14c61199cd30
+                        updatedAt: 1705615634
+                        createdAt: 1654131312
+                        scannedAt: 1705615584
+                        content: true
+                        directory: true
+                        contentChangedAt: 3192854
+                        hidden: 0
                         Location:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: number
-                              path:
-                                type: string
+                          - id: 1
+                            path: /movies
+
     "400":
       $ref: "../../responses/400.yaml"
     "401":

--- a/pms/paths/libraries.yaml
+++ b/pms/paths/libraries.yaml
@@ -13,6 +13,74 @@ get:
   responses:
     "200":
       description: The libraries available on the Server
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              MediaContainer:
+                type: object
+                properties:
+                  size:
+                    type: number
+                  allowSync:
+                    type: boolean
+                  title1:
+                    type: string
+                  Directory:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        allowSync:
+                          type: boolean
+                        art:
+                          type: string
+                        composite:
+                          type: string
+                        filters:
+                          type: boolean
+                        refreshing:
+                          type: boolean
+                        thumb:
+                          type: string
+                        key:
+                          type: string
+                        type:
+                          type: string
+                        title:
+                          type: string
+                        agent:
+                          type: string
+                        scanner:
+                          type: string
+                        language:
+                          type: string
+                        uuid:
+                          type: string
+                        updatedAt:
+                          type: number
+                        createdAt:
+                          type: number
+                        scannedAt:
+                          type: number
+                        content:
+                          type: boolean
+                        directory:
+                          type: boolean
+                        contentChangedAt:
+                          type: number
+                        hidden:
+                          type: number
+                        Location:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: number
+                              path:
+                                type: string
     "400":
       $ref: "../../responses/400.yaml"
     "401":


### PR DESCRIPTION
Hi there! Unsure of the format you'd like here, but I found the spec and am hoping to use it to build a Ruby gem! Ty so much for your work! Please let me know if there are any changes that I should make before requesting a merge.

# Intent
Add the response body for the getLibraries operationId.

# Work completed
1. Updated `/pms/paths/libraries.yaml` and added a `content` for the `200` response. 

I crafted this content section using https://swagger-toolbox.firebaseapp.com/ and the raw body from a request to my local Plex server.

2. Updated the dereferenced yaml file for pms

I did this using the command
```
swagger-cli bundle --dereference pms/pms-spec.yaml -t yaml -o plex-media-server-spec-dereferenced.yaml
```

# Downstream Ruby SDK Generation Proof
To prove that the sdk generation is working and includes the new changes, I am building a ruby gem and using it in a test project.

## Setup Test Ruby Project with Built Gem Files

1. Build ruby gem files using the command:
```
openapi-generator generate -i plex-media-server-spec-dereferenced.yaml -g ruby -o ../pms-api-ruby
```

2. Reference built gem in test project Gemfile

I did this by creating a Gemfile as follows:
```
source 'https://rubygems.org'

gem 'openapi_client', path: '/path/to/pms-api-ruby'

```

3. Include gem in project

In my project file, I include the built gem files as such:
```
# Load the gem
require 'bundler/setup'
require 'openapi_client'
```

4. Call the getLibraries endpoint

Example Ruby code used:
```
OpenapiClient.configure do |config|
  config.host = '192.168.x.x:32400'
  config.debugging = true
  # Configure API key authorization: accessToken
  config.api_key['accessToken'] = 'xxxxxxxxxxxxxxxxxxxxxx'
end

api_instance = OpenapiClient::LibraryApi.new

begin
  section = LIBRARY_SECTIONS[0]
rescue OpenapiClient::ApiError => e
  puts "Exception when calling LibraryApi->get_libraries: #{e}"
end
```

## Test Out With New Gem File Changes

Now, to test if the change (adding the response body) is reflected.

To do this, I ran the example ruby file above before and after the changes and compared the output.

### Output before changes
Before the change, the output showed nil for the Data value and a status code of 200

```
D, [2024-01-18T15:23:33.968923 #30434] DEBUG -- : Calling API: LibraryApi.get_libraries ...
GET /library/sections HTTP/1.1

HTTP/1.1 200 OK
D, [2024-01-18T15:23:34.034092 #30434] DEBUG -- : API called: LibraryApi#get_libraries
Data: nil
Status code: 200
```

### Output after changes
After the change, the output showed the expected body data for the Data value and a status code of 200

```
D, [2024-01-18T15:23:33.968923 #30434] DEBUG -- : Calling API: LibraryApi.get_libraries ...
GET /library/sections HTTP/1.1

HTTP/1.1 200 OK
D, [2024-01-18T15:23:34.034092 #30434] DEBUG -- : API called: LibraryApi#get_libraries
Data: #<OpenapiClient::GetLibraries200Response:0x000000015944d810 @media_container=# ...... shortened for brevity, but the data is here! >
Status code: 200
```
