### PR TITLE
adding missing 'schema'

### DIFF
--- a/pms/paths/server-preferences.yaml
+++ b/pms/paths/server-preferences.yaml
@@ -9,112 +9,113 @@ get:
       description: Server Preferences
       content:
         application/json:
-          type: object
-          properties:
-            MediaContainer:
-              type: object
-              properties:
-                size:
-                  type: integer
-                  format: int32
-                  example: 161
-                Setting:
-                  type: array
-                  items:
-                    oneOf:
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            example: FriendlyName
-                          label:
-                            type: string
-                            example: Friendly name
-                          summary:
-                            type: string
-                            example:
-                              This name will be used to identify this media server to other computers
-                              on your network. If you leave it blank, your computer's name
-                              will be used instead.
-                          type:
-                            type: string
-                            example: text
-                          default:
-                            type: string
-                            example: ""
-                          value:
-                            type: string
-                            example: Hera
-                          hidden:
-                            type: boolean
-                            example: false
-                          advanced:
-                            type: boolean
-                            example: false
-                          group:
-                            type: string
-                            example: general
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            example: ScheduledLibraryUpdateInterval
-                          label:
-                            type: string
-                            example: Library scan interval
-                          summary:
-                            type: string
-                            example: ""
-                          type:
-                            type: string
-                            example: int
-                          default:
-                            type: integer
-                            format: int32
-                            example: 3600
-                          value:
-                            type: integer
-                            format: int32
-                            example: 3600
-                          hidden:
-                            type: boolean
-                            example: false
-                          advanced:
-                            type: boolean
-                            example: false
-                          group:
-                            type: string
-                            example: library
-                          enumValues:
-                            type: string
-                            example:
-                              900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
-                              hours|21600:every 6 hours|43200:every 12 hours|86400:daily
-                  example:
-                    - id: FriendlyName
-                      label: Friendly name
-                      summary:
-                        This name will be used to identify this media server to other computers
-                        on your network. If you leave it blank, your computer's name will
-                        be used instead.
-                      type: text
-                      default: ""
-                      value: Hera
-                      hidden: false
-                      advanced: false
-                      group: general
-                    - id: ScheduledLibraryUpdateInterval
-                      label: Library scan interval
-                      summary: ""
-                      type: int
-                      default: 3600
-                      value: 3600
-                      hidden: false
-                      advanced: false
-                      group: library
-                      enumValues:
-                        900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
-                        hours|21600:every 6 hours|43200:every 12 hours|86400:daily
+          schema:
+            type: object
+            properties:
+              MediaContainer:
+                type: object
+                properties:
+                  size:
+                    type: integer
+                    format: int32
+                    example: 161
+                  Setting:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              example: FriendlyName
+                            label:
+                              type: string
+                              example: Friendly name
+                            summary:
+                              type: string
+                              example:
+                                This name will be used to identify this media server to other computers
+                                on your network. If you leave it blank, your computer's name
+                                will be used instead.
+                            type:
+                              type: string
+                              example: text
+                            default:
+                              type: string
+                              example: ""
+                            value:
+                              type: string
+                              example: Hera
+                            hidden:
+                              type: boolean
+                              example: false
+                            advanced:
+                              type: boolean
+                              example: false
+                            group:
+                              type: string
+                              example: general
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              example: ScheduledLibraryUpdateInterval
+                            label:
+                              type: string
+                              example: Library scan interval
+                            summary:
+                              type: string
+                              example: ""
+                            type:
+                              type: string
+                              example: int
+                            default:
+                              type: integer
+                              format: int32
+                              example: 3600
+                            value:
+                              type: integer
+                              format: int32
+                              example: 3600
+                            hidden:
+                              type: boolean
+                              example: false
+                            advanced:
+                              type: boolean
+                              example: false
+                            group:
+                              type: string
+                              example: library
+                            enumValues:
+                              type: string
+                              example:
+                                900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
+                                hours|21600:every 6 hours|43200:every 12 hours|86400:daily
+                    example:
+                      - id: FriendlyName
+                        label: Friendly name
+                        summary:
+                          This name will be used to identify this media server to other computers
+                          on your network. If you leave it blank, your computer's name will
+                          be used instead.
+                        type: text
+                        default: ""
+                        value: Hera
+                        hidden: false
+                        advanced: false
+                        group: general
+                      - id: ScheduledLibraryUpdateInterval
+                        label: Library scan interval
+                        summary: ""
+                        type: int
+                        default: 3600
+                        value: 3600
+                        hidden: false
+                        advanced: false
+                        group: library
+                        enumValues:
+                          900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
+                          hours|21600:every 6 hours|43200:every 12 hours|86400:daily
 
     "400":
       $ref: "../../responses/400.yaml"


### PR DESCRIPTION
Went to generate a Ruby sdk and received the below error, which I traced back to [today's edits](https://github.com/LukeHagar/plex-api-spec/commit/91fc49bc8cd58a6d6ef8f8354b95b38ab82e8d7c) on pms/paths/server-preferences.yaml and a missing 'schema' key.

Command:
```
openapi-generator generate -i plex-media-server-spec-dereferenced.yaml -g ruby -o ../pms-api-ruby
```

Error:
```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 2, Warning count: 0
Errors:
	-attribute paths.'/:/prefs'(get).responses.200.content.'application/json'.type is unexpected
	-attribute paths.'/:/prefs'(get).responses.200.content.'application/json'.properties is unexpected

	at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:701)
	at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:728)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:519)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```