### PR TITLE
Adding 200 response to library-content-all

### DIFF
--- a/pms/paths/library-content-all.yaml
+++ b/pms/paths/library-content-all.yaml
@@ -28,6 +28,391 @@ get:
   responses:
     "200":
       description: The details of the library
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              MediaContainer:
+                type: object
+                properties:
+                  size:
+                    type: integer
+                    format: int32
+                    example: 1
+                  allowSync:
+                    type: boolean
+                    example: true
+                  art:
+                    type: string
+                    example: /:/resources/movie-fanart.jpg
+                  identifier:
+                    type: string
+                    example: com.plexapp.plugins.library
+                  librarySectionID:
+                    type: integer
+                    format: int32
+                    example: 1
+                  librarySectionTitle:
+                    type: string
+                    example: Movies
+                  librarySectionUUID:
+                    type: string
+                    example: cfc899d7-3000-46f6-8489-b9592714ada5
+                  mediaTagPrefix:
+                    type: string
+                    example: /system/bundle/media/flags/
+                  mediaTagVersion:
+                    type: integer
+                    format: int32
+                    example: 1698860922
+                  thumb:
+                    type: string
+                    example: /:/resources/movie.png
+                  title1:
+                    type: string
+                    example: Movies
+                  title2:
+                    type: string
+                    example: All Movies
+                  viewGroup:
+                    type: string
+                    example: movie
+                  viewMode:
+                    type: integer
+                    format: int32
+                    example: 65592
+                  Metadata:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        ratingKey:
+                          type: string
+                          example: "17"
+                        key:
+                          type: string
+                          example: /library/metadata/17
+                        guid:
+                          type: string
+                          example: plex://movie/5d77683f6f4521001ea9dc53
+                        studio:
+                          type: string
+                          example: Universal Pictures
+                        type:
+                          type: string
+                          example: movie
+                        title:
+                          type: string
+                          example: Serenity
+                        contentRating:
+                          type: string
+                          example: PG-13
+                        summary:
+                          type: string
+                          example: Serenity continues the story of the TV series it was based upon
+                            ("Firefly"). River Tam had a secret - one in which she's not
+                            even aware - so dangerous, no one's safe, as an Alliance
+                            operative's sent to capture her, and all others are considered
+                            irrelevant to his job.
+                        rating:
+                          type: number
+                          example: 8.2
+                        audienceRating:
+                          type: number
+                          example: 9.1
+                        year:
+                          type: integer
+                          format: int32
+                          example: 2005
+                        tagline:
+                          type: string
+                          example: They aim to misbehave.
+                        thumb:
+                          type: string
+                          example: /library/metadata/17/thumb/1705637165
+                        art:
+                          type: string
+                          example: /library/metadata/17/art/1705637165
+                        duration:
+                          type: integer
+                          format: int32
+                          example: 141417
+                        originallyAvailableAt:
+                          type: string
+                          format: date
+                          example: 2005-09-29
+                        addedAt:
+                          type: integer
+                          format: int32
+                          example: 1705637164
+                        updatedAt:
+                          type: integer
+                          format: int32
+                          example: 1705637165
+                        audienceRatingImage:
+                          type: string
+                          example: rottentomatoes://image.rating.upright
+                        hasPremiumPrimaryExtra:
+                          type: string
+                          example: "1"
+                        ratingImage:
+                          type: string
+                          example: rottentomatoes://image.rating.ripe
+                        Media:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                format: int32
+                                example: 15
+                              duration:
+                                type: integer
+                                format: int32
+                                example: 141417
+                              bitrate:
+                                type: integer
+                                format: int32
+                                example: 2278
+                              width:
+                                type: integer
+                                format: int32
+                                example: 1920
+                              height:
+                                type: integer
+                                format: int32
+                                example: 814
+                              aspectRatio:
+                                type: number
+                                example: 2.35
+                              audioChannels:
+                                type: integer
+                                format: int32
+                                example: 2
+                              audioCodec:
+                                type: string
+                                example: aac
+                              videoCodec:
+                                type: string
+                                example: h264
+                              videoResolution:
+                                type: string
+                                example: "1080"
+                              container:
+                                type: string
+                                example: mp4
+                              videoFrameRate:
+                                type: string
+                                example: 24p
+                              optimizedForStreaming:
+                                type: integer
+                                format: int32
+                                example: 0
+                              audioProfile:
+                                type: string
+                                example: lc
+                              has64bitOffsets:
+                                type: boolean
+                                example: false
+                              videoProfile:
+                                type: string
+                                example: high
+                              Part:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    id:
+                                      type: integer
+                                      format: int32
+                                      example: 15
+                                    key:
+                                      type: string
+                                      example: /library/parts/15/1705637151/file.mp4
+                                    duration:
+                                      type: integer
+                                      format: int32
+                                      example: 141417
+                                    file:
+                                      type: string
+                                      example: /movies/Serenity (2005)/Serenity (2005).mp4
+                                    size:
+                                      type: integer
+                                      format: int32
+                                      example: 40271948
+                                    audioProfile:
+                                      type: string
+                                      example: lc
+                                    container:
+                                      type: string
+                                      example: mp4
+                                    has64bitOffsets:
+                                      type: boolean
+                                      example: false
+                                    optimizedForStreaming:
+                                      type: boolean
+                                      example: false
+                                    videoProfile:
+                                      type: string
+                                      example: high
+                                example:
+                                  - id: 15
+                                    key: /library/parts/15/1705637151/file.mp4
+                                    duration: 141417
+                                    file: /movies/Serenity (2005)/Serenity (2005).mp4
+                                    size: 40271948
+                                    audioProfile: lc
+                                    container: mp4
+                                    has64bitOffsets: false
+                                    optimizedForStreaming: false
+                                    videoProfile: high
+                          example:
+                            - id: 15
+                              duration: 141417
+                              bitrate: 2278
+                              width: 1920
+                              height: 814
+                              aspectRatio: 2.35
+                              audioChannels: 2
+                              audioCodec: aac
+                              videoCodec: h264
+                              videoResolution: "1080"
+                              container: mp4
+                              videoFrameRate: 24p
+                              optimizedForStreaming: 0
+                              audioProfile: lc
+                              has64bitOffsets: false
+                              videoProfile: high
+                              Part:
+                                - id: 15
+                                  key: /library/parts/15/1705637151/file.mp4
+                                  duration: 141417
+                                  file: /movies/Serenity (2005)/Serenity (2005).mp4
+                                  size: 40271948
+                                  audioProfile: lc
+                                  container: mp4
+                                  has64bitOffsets: false
+                                  optimizedForStreaming: false
+                                  videoProfile: high
+                        Genre:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              tag:
+                                type: string
+                                example: Action
+                          example:
+                            - tag: Action
+                        Country:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              tag:
+                                type: string
+                                example: United States of America
+                          example:
+                            - tag: United States of America
+                        Director:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              tag:
+                                type: string
+                                example: Joss Whedon
+                          example:
+                            - tag: Joss Whedon
+                        Writer:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              tag:
+                                type: string
+                                example: Joss Whedon
+                          example:
+                            - tag: Joss Whedon
+                        Role:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              tag:
+                                type: string
+                                example: Gina Torres
+                          example:
+                            - tag: Gina Torres
+                    example:
+                      - ratingKey: "17"
+                        key: /library/metadata/17
+                        guid: plex://movie/5d77683f6f4521001ea9dc53
+                        studio: Universal Pictures
+                        type: movie
+                        title: Serenity
+                        contentRating: PG-13
+                        summary: Serenity continues the story of the TV series it was based upon
+                          ("Firefly"). River Tam had a secret - one in which she's not even
+                          aware - so dangerous, no one's safe, as an Alliance operative's
+                          sent to capture her, and all others are considered irrelevant to
+                          his job.
+                        rating: 8.2
+                        audienceRating: 9.1
+                        year: 2005
+                        tagline: They aim to misbehave.
+                        thumb: /library/metadata/17/thumb/1705637165
+                        art: /library/metadata/17/art/1705637165
+                        duration: 141417
+                        originallyAvailableAt: 2005-09-29
+                        addedAt: 1705637164
+                        updatedAt: 1705637165
+                        audienceRatingImage: rottentomatoes://image.rating.upright
+                        hasPremiumPrimaryExtra: "1"
+                        ratingImage: rottentomatoes://image.rating.ripe
+                        Media:
+                          - id: 15
+                            duration: 141417
+                            bitrate: 2278
+                            width: 1920
+                            height: 814
+                            aspectRatio: 2.35
+                            audioChannels: 2
+                            audioCodec: aac
+                            videoCodec: h264
+                            videoResolution: "1080"
+                            container: mp4
+                            videoFrameRate: 24p
+                            optimizedForStreaming: 0
+                            audioProfile: lc
+                            has64bitOffsets: false
+                            videoProfile: high
+                            Part:
+                              - id: 15
+                                key: /library/parts/15/1705637151/file.mp4
+                                duration: 141417
+                                file: /movies/Serenity (2005)/Serenity (2005).mp4
+                                size: 40271948
+                                audioProfile: lc
+                                container: mp4
+                                has64bitOffsets: false
+                                optimizedForStreaming: false
+                                videoProfile: high
+                        Genre:
+                          - tag: Science Fiction
+                          - tag: Action
+                        Country:
+                          - tag: United States of America
+                        Director:
+                          - tag: Joss Whedon
+                        Writer:
+                          - tag: Joss Whedon
+                        Role:
+                          - tag: Nathan Fillion
+                          - tag: Summer Glau
+                          - tag: Gina Torres
     "400":
       $ref: "../../responses/400.yaml"
     "401":

--- a/pms/paths/server-preferences.yaml
+++ b/pms/paths/server-preferences.yaml
@@ -9,112 +9,113 @@ get:
       description: Server Preferences
       content:
         application/json:
-          type: object
-          properties:
-            MediaContainer:
-              type: object
-              properties:
-                size:
-                  type: integer
-                  format: int32
-                  example: 161
-                Setting:
-                  type: array
-                  items:
-                    oneOf:
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            example: FriendlyName
-                          label:
-                            type: string
-                            example: Friendly name
-                          summary:
-                            type: string
-                            example:
-                              This name will be used to identify this media server to other computers
-                              on your network. If you leave it blank, your computer's name
-                              will be used instead.
-                          type:
-                            type: string
-                            example: text
-                          default:
-                            type: string
-                            example: ""
-                          value:
-                            type: string
-                            example: Hera
-                          hidden:
-                            type: boolean
-                            example: false
-                          advanced:
-                            type: boolean
-                            example: false
-                          group:
-                            type: string
-                            example: general
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            example: ScheduledLibraryUpdateInterval
-                          label:
-                            type: string
-                            example: Library scan interval
-                          summary:
-                            type: string
-                            example: ""
-                          type:
-                            type: string
-                            example: int
-                          default:
-                            type: integer
-                            format: int32
-                            example: 3600
-                          value:
-                            type: integer
-                            format: int32
-                            example: 3600
-                          hidden:
-                            type: boolean
-                            example: false
-                          advanced:
-                            type: boolean
-                            example: false
-                          group:
-                            type: string
-                            example: library
-                          enumValues:
-                            type: string
-                            example:
-                              900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
-                              hours|21600:every 6 hours|43200:every 12 hours|86400:daily
-                  example:
-                    - id: FriendlyName
-                      label: Friendly name
-                      summary:
-                        This name will be used to identify this media server to other computers
-                        on your network. If you leave it blank, your computer's name will
-                        be used instead.
-                      type: text
-                      default: ""
-                      value: Hera
-                      hidden: false
-                      advanced: false
-                      group: general
-                    - id: ScheduledLibraryUpdateInterval
-                      label: Library scan interval
-                      summary: ""
-                      type: int
-                      default: 3600
-                      value: 3600
-                      hidden: false
-                      advanced: false
-                      group: library
-                      enumValues:
-                        900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
-                        hours|21600:every 6 hours|43200:every 12 hours|86400:daily
+          schema:
+            type: object
+            properties:
+              MediaContainer:
+                type: object
+                properties:
+                  size:
+                    type: integer
+                    format: int32
+                    example: 161
+                  Setting:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              example: FriendlyName
+                            label:
+                              type: string
+                              example: Friendly name
+                            summary:
+                              type: string
+                              example:
+                                This name will be used to identify this media server to other computers
+                                on your network. If you leave it blank, your computer's name
+                                will be used instead.
+                            type:
+                              type: string
+                              example: text
+                            default:
+                              type: string
+                              example: ""
+                            value:
+                              type: string
+                              example: Hera
+                            hidden:
+                              type: boolean
+                              example: false
+                            advanced:
+                              type: boolean
+                              example: false
+                            group:
+                              type: string
+                              example: general
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              example: ScheduledLibraryUpdateInterval
+                            label:
+                              type: string
+                              example: Library scan interval
+                            summary:
+                              type: string
+                              example: ""
+                            type:
+                              type: string
+                              example: int
+                            default:
+                              type: integer
+                              format: int32
+                              example: 3600
+                            value:
+                              type: integer
+                              format: int32
+                              example: 3600
+                            hidden:
+                              type: boolean
+                              example: false
+                            advanced:
+                              type: boolean
+                              example: false
+                            group:
+                              type: string
+                              example: library
+                            enumValues:
+                              type: string
+                              example:
+                                900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
+                                hours|21600:every 6 hours|43200:every 12 hours|86400:daily
+                    example:
+                      - id: FriendlyName
+                        label: Friendly name
+                        summary:
+                          This name will be used to identify this media server to other computers
+                          on your network. If you leave it blank, your computer's name will
+                          be used instead.
+                        type: text
+                        default: ""
+                        value: Hera
+                        hidden: false
+                        advanced: false
+                        group: general
+                      - id: ScheduledLibraryUpdateInterval
+                        label: Library scan interval
+                        summary: ""
+                        type: int
+                        default: 3600
+                        value: 3600
+                        hidden: false
+                        advanced: false
+                        group: library
+                        enumValues:
+                          900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
+                          hours|21600:every 6 hours|43200:every 12 hours|86400:daily
 
     "400":
       $ref: "../../responses/400.yaml"


### PR DESCRIPTION
# Intent
Updating the `pms/paths/library-content-all.yaml` file to add a 200 response format for the `getLibraryItems` endpoint.

# Testing
I've documented my testing set up by generating a Ruby SDK [here](https://gist.github.com/johnhebron/3c6779b1d10d29015013e2fd03db2360).

For this PR, the Ruby test code was:
```
libraries = api_instance.get_library_items(1)
```

Before, response data was nil:
<img width="1280" alt="Screenshot 2024-01-19 at 6 21 59 PM" src="https://github.com/LukeHagar/plex-api-spec/assets/7632624/1ac6196a-98bb-41de-af6c-1f2729dc1753">

After, response data is present:
<img width="1280" alt="Screenshot 2024-01-19 at 6 27 42 PM" src="https://github.com/LukeHagar/plex-api-spec/assets/7632624/1a24d8b7-64d4-47e6-8f39-ee758fdfa67a">
