### PR TITLE
adding 200 response format for getMetadata

### DIFF
--- a/pms/paths/metadata.yaml
+++ b/pms/paths/metadata.yaml
@@ -16,6 +16,816 @@ get:
   responses:
     "200":
       description: The children of the library item.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              MediaContainer:
+                type: object
+                properties:
+                  size:
+                    type: integer
+                    format: int32
+                    example: 1
+                  allowSync:
+                    type: boolean
+                    example: true
+                  identifier:
+                    type: string
+                    example: com.plexapp.plugins.library
+                  librarySectionID:
+                    type: integer
+                    format: int32
+                    example: 1
+                  librarySectionTitle:
+                    type: string
+                    example: Movies
+                  librarySectionUUID:
+                    type: string
+                    example: cfc899d7-3000-46f6-8489-b9592714ada5
+                  mediaTagPrefix:
+                    type: string
+                    example: /system/bundle/media/flags/
+                  mediaTagVersion:
+                    type: integer
+                    format: int32
+                    example: 1698860922
+                  Metadata:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        ratingKey:
+                          type: string
+                          example: "17"
+                        key:
+                          type: string
+                          example: /library/metadata/17
+                        guid:
+                          type: string
+                          example: plex://movie/5d77683f6f4521001ea9dc53
+                        studio:
+                          type: string
+                          example: Universal Pictures
+                        type:
+                          type: string
+                          example: movie
+                        title:
+                          type: string
+                          example: Serenity
+                        librarySectionTitle:
+                          type: string
+                          example: Movies
+                        librarySectionID:
+                          type: integer
+                          format: int32
+                          example: 1
+                        librarySectionKey:
+                          type: string
+                          example: /library/sections/1
+                        contentRating:
+                          type: string
+                          example: PG-13
+                        summary:
+                          type: string
+                          example: Serenity continues the story of the TV series it was based upon
+                            ("Firefly"). River Tam had a secret - one in which she's not
+                            even aware - so dangerous, no one's safe, as an Alliance
+                            operative's sent to capture her, and all others are considered
+                            irrelevant to his job.
+                        rating:
+                          type: number
+                          example: 8.2
+                        audienceRating:
+                          type: number
+                          example: 9.1
+                        year:
+                          type: integer
+                          format: int32
+                          example: 2005
+                        tagline:
+                          type: string
+                          example: They aim to misbehave.
+                        thumb:
+                          type: string
+                          example: /library/metadata/17/thumb/1705637165
+                        art:
+                          type: string
+                          example: /library/metadata/17/art/1705637165
+                        duration:
+                          type: integer
+                          format: int32
+                          example: 141417
+                        originallyAvailableAt:
+                          type: string
+                          format: date
+                          example: 2005-09-29
+                        addedAt:
+                          type: integer
+                          format: int32
+                          example: 1705637164
+                        updatedAt:
+                          type: integer
+                          format: int32
+                          example: 1705637165
+                        audienceRatingImage:
+                          type: string
+                          example: rottentomatoes://image.rating.upright
+                        hasPremiumPrimaryExtra:
+                          type: string
+                          example: "1"
+                        ratingImage:
+                          type: string
+                          example: rottentomatoes://image.rating.ripe
+                        Media:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                format: int32
+                                example: 15
+                              duration:
+                                type: integer
+                                format: int32
+                                example: 141417
+                              bitrate:
+                                type: integer
+                                format: int32
+                                example: 2278
+                              width:
+                                type: integer
+                                format: int32
+                                example: 1920
+                              height:
+                                type: integer
+                                format: int32
+                                example: 814
+                              aspectRatio:
+                                type: number
+                                example: 2.35
+                              audioChannels:
+                                type: integer
+                                format: int32
+                                example: 2
+                              audioCodec:
+                                type: string
+                                example: aac
+                              videoCodec:
+                                type: string
+                                example: h264
+                              videoResolution:
+                                type: string
+                                example: "1080"
+                              container:
+                                type: string
+                                example: mp4
+                              videoFrameRate:
+                                type: string
+                                example: 24p
+                              optimizedForStreaming:
+                                type: integer
+                                format: int32
+                                example: 0
+                              audioProfile:
+                                type: string
+                                example: lc
+                              has64bitOffsets:
+                                type: boolean
+                                example: false
+                              videoProfile:
+                                type: string
+                                example: high
+                              Part:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    id:
+                                      type: integer
+                                      format: int32
+                                      example: 15
+                                    key:
+                                      type: string
+                                      example: /library/parts/15/1705637151/file.mp4
+                                    duration:
+                                      type: integer
+                                      format: int32
+                                      example: 141417
+                                    file:
+                                      type: string
+                                      example: /movies/Serenity (2005)/Serenity (2005).mp4
+                                    size:
+                                      type: integer
+                                      format: int32
+                                      example: 40271948
+                                    audioProfile:
+                                      type: string
+                                      example: lc
+                                    container:
+                                      type: string
+                                      example: mp4
+                                    has64bitOffsets:
+                                      type: boolean
+                                      example: false
+                                    optimizedForStreaming:
+                                      type: boolean
+                                      example: false
+                                    videoProfile:
+                                      type: string
+                                      example: high
+                                    Stream:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          id:
+                                            type: integer
+                                            format: int32
+                                            example: 29
+                                          streamType:
+                                            type: integer
+                                            format: int32
+                                            example: 2
+                                          default:
+                                            type: boolean
+                                            example: true
+                                          codec:
+                                            type: string
+                                            example: aac
+                                          index:
+                                            type: integer
+                                            format: int32
+                                            example: 0
+                                          bitrate:
+                                            type: integer
+                                            format: int32
+                                            example: 128
+                                          bitDepth:
+                                            type: integer
+                                            format: int32
+                                            example: 8
+                                          chromaLocation:
+                                            type: string
+                                            example: left
+                                          chromaSubsampling:
+                                            type: string
+                                            example: 4:2:0
+                                          codedHeight:
+                                            type: integer
+                                            format: int32
+                                            example: 816
+                                          codedWidth:
+                                            type: integer
+                                            format: int32
+                                            example: 1920
+                                          colorPrimaries:
+                                            type: string
+                                            example: bt709
+                                          colorRange:
+                                            type: string
+                                            example: tv
+                                          colorSpace:
+                                            type: string
+                                            example: bt709
+                                          colorTrc:
+                                            type: string
+                                            example: bt709
+                                          frameRate:
+                                            type: integer
+                                            format: int32
+                                            example: 24
+                                          hasScalingMatrix:
+                                            type: boolean
+                                            example: false
+                                          height:
+                                            type: integer
+                                            format: int32
+                                            example: 814
+                                          level:
+                                            type: integer
+                                            format: int32
+                                            example: 40
+                                          profile:
+                                            type: string
+                                            example: lc
+                                          refFrames:
+                                            type: integer
+                                            format: int32
+                                            example: 4
+                                          scanType:
+                                            type: string
+                                            example: progressive
+                                          streamIdentifier:
+                                            type: string
+                                            example: "1"
+                                          width:
+                                            type: integer
+                                            format: int32
+                                            example: 1920
+                                          displayTitle:
+                                            type: string
+                                            example: English (AAC Stereo)
+                                          extendedDisplayTitle:
+                                            type: string
+                                            example: English (AAC Stereo)
+                                          selected:
+                                            type: boolean
+                                            example: true
+                                          channels:
+                                            type: integer
+                                            format: int32
+                                            example: 2
+                                          language:
+                                            type: string
+                                            example: English
+                                          languageTag:
+                                            type: string
+                                            example: en
+                                          languageCode:
+                                            type: string
+                                            example: eng
+                                          samplingRate:
+                                            type: integer
+                                            format: int32
+                                            example: 44100
+                                      example:
+                                        - id: 29
+                                          streamType: 2
+                                          default: true
+                                          codec: aac
+                                          index: 0
+                                          bitrate: 128
+                                          bitDepth: 8
+                                          chromaLocation: left
+                                          chromaSubsampling: 4:2:0
+                                          codedHeight: 816
+                                          codedWidth: 1920
+                                          colorPrimaries: bt709
+                                          colorRange: tv
+                                          colorSpace: bt709
+                                          colorTrc: bt709
+                                          frameRate: 24
+                                          hasScalingMatrix: false
+                                          height: 814
+                                          level: 40
+                                          profile: lc
+                                          refFrames: 4
+                                          scanType: progressive
+                                          streamIdentifier: "1"
+                                          width: 1920
+                                          displayTitle: English (AAC Stereo)
+                                          extendedDisplayTitle: English (AAC Stereo)
+                                          selected: true
+                                          channels: 2
+                                          language: English
+                                          languageTag: en
+                                          languageCode: eng
+                                          samplingRate: 44100
+                                example:
+                                  - id: 15
+                                    key: /library/parts/15/1705637151/file.mp4
+                                    duration: 141417
+                                    file: /movies/Serenity (2005)/Serenity (2005).mp4
+                                    size: 40271948
+                                    audioProfile: lc
+                                    container: mp4
+                                    has64bitOffsets: false
+                                    optimizedForStreaming: false
+                                    videoProfile: high
+                                    Stream:
+                                      - id: 30
+                                        streamType: 1
+                                        default: true
+                                        codec: h264
+                                        index: 1
+                                        bitrate: 2160
+                                        bitDepth: 8
+                                        chromaLocation: left
+                                        chromaSubsampling: 4:2:0
+                                        codedHeight: 816
+                                        codedWidth: 1920
+                                        colorPrimaries: bt709
+                                        colorRange: tv
+                                        colorSpace: bt709
+                                        colorTrc: bt709
+                                        frameRate: 24
+                                        hasScalingMatrix: false
+                                        height: 814
+                                        level: 40
+                                        profile: high
+                                        refFrames: 4
+                                        scanType: progressive
+                                        streamIdentifier: "2"
+                                        width: 1920
+                                        displayTitle: 1080p (H.264)
+                                        extendedDisplayTitle: 1080p (H.264)
+                                      - id: 29
+                                        streamType: 2
+                                        selected: true
+                                        default: true
+                                        codec: aac
+                                        index: 0
+                                        channels: 2
+                                        bitrate: 128
+                                        language: English
+                                        languageTag: en
+                                        languageCode: eng
+                                        profile: lc
+                                        samplingRate: 44100
+                                        streamIdentifier: "1"
+                                        displayTitle: English (AAC Stereo)
+                                        extendedDisplayTitle: English (AAC Stereo)
+                          example:
+                            - id: 15
+                              duration: 141417
+                              bitrate: 2278
+                              width: 1920
+                              height: 814
+                              aspectRatio: 2.35
+                              audioChannels: 2
+                              audioCodec: aac
+                              videoCodec: h264
+                              videoResolution: "1080"
+                              container: mp4
+                              videoFrameRate: 24p
+                              optimizedForStreaming: 0
+                              audioProfile: lc
+                              has64bitOffsets: false
+                              videoProfile: high
+                              Part:
+                                - id: 15
+                                  key: /library/parts/15/1705637151/file.mp4
+                                  duration: 141417
+                                  file: /movies/Serenity (2005)/Serenity (2005).mp4
+                                  size: 40271948
+                                  audioProfile: lc
+                                  container: mp4
+                                  has64bitOffsets: false
+                                  optimizedForStreaming: false
+                                  videoProfile: high
+                                  Stream:
+                                    - id: 30
+                                      streamType: 1
+                                      default: true
+                                      codec: h264
+                                      index: 1
+                                      bitrate: 2160
+                                      bitDepth: 8
+                                      chromaLocation: left
+                                      chromaSubsampling: 4:2:0
+                                      codedHeight: 816
+                                      codedWidth: 1920
+                                      colorPrimaries: bt709
+                                      colorRange: tv
+                                      colorSpace: bt709
+                                      colorTrc: bt709
+                                      frameRate: 24
+                                      hasScalingMatrix: false
+                                      height: 814
+                                      level: 40
+                                      profile: high
+                                      refFrames: 4
+                                      scanType: progressive
+                                      streamIdentifier: "2"
+                                      width: 1920
+                                      displayTitle: 1080p (H.264)
+                                      extendedDisplayTitle: 1080p (H.264)
+                                    - id: 29
+                                      streamType: 2
+                                      selected: true
+                                      default: true
+                                      codec: aac
+                                      index: 0
+                                      channels: 2
+                                      bitrate: 128
+                                      language: English
+                                      languageTag: en
+                                      languageCode: eng
+                                      profile: lc
+                                      samplingRate: 44100
+                                      streamIdentifier: "1"
+                                      displayTitle: English (AAC Stereo)
+                                      extendedDisplayTitle: English (AAC Stereo)
+                        Genre:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                format: int32
+                                example: 184
+                              filter:
+                                type: string
+                                example: genre=184
+                              tag:
+                                type: string
+                                example: Thriller
+                          example:
+                            - id: 184
+                              filter: genre=184
+                              tag: Thriller
+                        Country:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                format: int32
+                                example: 116
+                              filter:
+                                type: string
+                                example: country=116
+                              tag:
+                                type: string
+                                example: United States of America
+                          example:
+                            - id: 116
+                              filter: country=116
+                              tag: United States of America
+                        Guid:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                example: tvdb://2337
+                          example:
+                            - id: tvdb://2337
+                        Rating:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              image:
+                                type: string
+                                example: themoviedb://image.rating
+                              value:
+                                type: number
+                                example: 7.4
+                              type:
+                                type: string
+                                example: audience
+                          example:
+                            - image: themoviedb://image.rating
+                              value: 7.4
+                              type: audience
+                        Director:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                format: int32
+                                example: 130
+                              filter:
+                                type: string
+                                example: director=130
+                              tag:
+                                type: string
+                                example: Joss Whedon
+                              tagKey:
+                                type: string
+                                example: 5d776828880197001ec90e8f
+                              thumb:
+                                type: string
+                                example: https://metadata-static.plex.tv/people/5d776828880197001ec90e8f.jpg
+                          example:
+                            - id: 130
+                              filter: director=130
+                              tag: Joss Whedon
+                              tagKey: 5d776828880197001ec90e8f
+                              thumb: https://metadata-static.plex.tv/people/5d776828880197001ec90e8f.jpg
+                        Writer:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                format: int32
+                                example: 132
+                              filter:
+                                type: string
+                                example: writer=132
+                              tag:
+                                type: string
+                                example: Joss Whedon
+                              tagKey:
+                                type: string
+                                example: 5d776828880197001ec90e8f
+                              thumb:
+                                type: string
+                                example: https://metadata-static.plex.tv/people/5d776828880197001ec90e8f.jpg
+                          example:
+                            - id: 132
+                              filter: writer=132
+                              tag: Joss Whedon
+                              tagKey: 5d776828880197001ec90e8f
+                              thumb: https://metadata-static.plex.tv/people/5d776828880197001ec90e8f.jpg
+                        Role:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                format: int32
+                                example: 220
+                              filter:
+                                type: string
+                                example: actor=220
+                              tag:
+                                type: string
+                                example: Dennis Keiffer
+                              tagKey:
+                                type: string
+                                example: 5d77683554f42c001f8c4708
+                              role:
+                                type: string
+                                example: Bar Guy (uncredited)
+                              thumb:
+                                type: string
+                                example: https://metadata-static.plex.tv/6/people/648e9a7ea1d537bccfcd7615134b78ce.jpg
+                          example:
+                            - id: 220
+                              filter: actor=220
+                              tag: Dennis Keiffer
+                              tagKey: 5d77683554f42c001f8c4708
+                              role: Bar Guy (uncredited)
+                              thumb: https://metadata-static.plex.tv/6/people/648e9a7ea1d537bccfcd7615134b78ce.jpg
+                        Producer:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                format: int32
+                                example: 221
+                              filter:
+                                type: string
+                                example: producer=221
+                              tag:
+                                type: string
+                                example: Barry Mendel
+                              tagKey:
+                                type: string
+                                example: 5d776826961905001eb90e2b
+                              thumb:
+                                type: string
+                                example: https://metadata-static.plex.tv/8/people/87877371326a964634d18556d94547e1.jpg
+                          example:
+                            - id: 221
+                              filter: producer=221
+                              tag: Barry Mendel
+                              tagKey: 5d776826961905001eb90e2b
+                              thumb: https://metadata-static.plex.tv/8/people/87877371326a964634d18556d94547e1.jpg
+                    example:
+                      - ratingKey: "17"
+                        key: /library/metadata/17
+                        guid: plex://movie/5d77683f6f4521001ea9dc53
+                        studio: Universal Pictures
+                        type: movie
+                        title: Serenity
+                        librarySectionTitle: Movies
+                        librarySectionID: 1
+                        librarySectionKey: /library/sections/1
+                        contentRating: PG-13
+                        summary: Serenity continues the story of the TV series it was based upon
+                          ("Firefly"). River Tam had a secret - one in which she's not even
+                          aware - so dangerous, no one's safe, as an Alliance operative's
+                          sent to capture her, and all others are considered irrelevant to
+                          his job.
+                        rating: 8.2
+                        audienceRating: 9.1
+                        year: 2005
+                        tagline: They aim to misbehave.
+                        thumb: /library/metadata/17/thumb/1705637165
+                        art: /library/metadata/17/art/1705637165
+                        duration: 141417
+                        originallyAvailableAt: 2005-09-29
+                        addedAt: 1705637164
+                        updatedAt: 1705637165
+                        audienceRatingImage: rottentomatoes://image.rating.upright
+                        hasPremiumPrimaryExtra: "1"
+                        ratingImage: rottentomatoes://image.rating.ripe
+                        Media:
+                          - id: 15
+                            duration: 141417
+                            bitrate: 2278
+                            width: 1920
+                            height: 814
+                            aspectRatio: 2.35
+                            audioChannels: 2
+                            audioCodec: aac
+                            videoCodec: h264
+                            videoResolution: "1080"
+                            container: mp4
+                            videoFrameRate: 24p
+                            optimizedForStreaming: 0
+                            audioProfile: lc
+                            has64bitOffsets: false
+                            videoProfile: high
+                            Part:
+                              - id: 15
+                                key: /library/parts/15/1705637151/file.mp4
+                                duration: 141417
+                                file: /movies/Serenity (2005)/Serenity (2005).mp4
+                                size: 40271948
+                                audioProfile: lc
+                                container: mp4
+                                has64bitOffsets: false
+                                optimizedForStreaming: false
+                                videoProfile: high
+                                Stream:
+                                  - id: 30
+                                    streamType: 1
+                                    default: true
+                                    codec: h264
+                                    index: 1
+                                    bitrate: 2160
+                                    bitDepth: 8
+                                    chromaLocation: left
+                                    chromaSubsampling: 4:2:0
+                                    codedHeight: 816
+                                    codedWidth: 1920
+                                    colorPrimaries: bt709
+                                    colorRange: tv
+                                    colorSpace: bt709
+                                    colorTrc: bt709
+                                    frameRate: 24
+                                    hasScalingMatrix: false
+                                    height: 814
+                                    level: 40
+                                    profile: high
+                                    refFrames: 4
+                                    scanType: progressive
+                                    streamIdentifier: "2"
+                                    width: 1920
+                                    displayTitle: 1080p (H.264)
+                                    extendedDisplayTitle: 1080p (H.264)
+                                  - id: 29
+                                    streamType: 2
+                                    selected: true
+                                    default: true
+                                    codec: aac
+                                    index: 0
+                                    channels: 2
+                                    bitrate: 128
+                                    language: English
+                                    languageTag: en
+                                    languageCode: eng
+                                    profile: lc
+                                    samplingRate: 44100
+                                    streamIdentifier: "1"
+                                    displayTitle: English (AAC Stereo)
+                                    extendedDisplayTitle: English (AAC Stereo)
+                        Genre:
+                          - id: 5
+                            filter: genre=5
+                            tag: Science Fiction
+                        Country:
+                          - id: 116
+                            filter: country=116
+                            tag: United States of America
+                        Guid:
+                          - id: imdb://tt0379786
+                        Rating:
+                          - image: imdb://image.rating
+                            value: 7.8
+                            type: audience
+                        Director:
+                          - id: 130
+                            filter: director=130
+                            tag: Joss Whedon
+                            tagKey: 5d776828880197001ec90e8f
+                            thumb: https://metadata-static.plex.tv/people/5d776828880197001ec90e8f.jpg
+                        Writer:
+                          - id: 132
+                            filter: writer=132
+                            tag: Joss Whedon
+                            tagKey: 5d776828880197001ec90e8f
+                            thumb: https://metadata-static.plex.tv/people/5d776828880197001ec90e8f.jpg
+                        Role:
+                          - id: 8
+                            filter: actor=8
+                            tag: Nathan Fillion
+                            tagKey: 5d7768286f4521001ea9945c
+                            role: Malcolm "Mal" Reynolds
+                            thumb: https://metadata-static.plex.tv/4/people/4a2890ca346eb832500b1ed0add89d5e.jpg
+                        Producer:
+                          - id: 221
+                            filter: producer=221
+                            tag: Barry Mendel
+                            tagKey: 5d776826961905001eb90e2b
+                            thumb: https://metadata-static.plex.tv/8/people/87877371326a964634d18556d94547e1.jpg
     "400":
       $ref: "../../responses/400.yaml"
     "401":

--- a/pms/paths/server-preferences.yaml
+++ b/pms/paths/server-preferences.yaml
@@ -9,112 +9,113 @@ get:
       description: Server Preferences
       content:
         application/json:
-          type: object
-          properties:
-            MediaContainer:
-              type: object
-              properties:
-                size:
-                  type: integer
-                  format: int32
-                  example: 161
-                Setting:
-                  type: array
-                  items:
-                    oneOf:
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            example: FriendlyName
-                          label:
-                            type: string
-                            example: Friendly name
-                          summary:
-                            type: string
-                            example:
-                              This name will be used to identify this media server to other computers
-                              on your network. If you leave it blank, your computer's name
-                              will be used instead.
-                          type:
-                            type: string
-                            example: text
-                          default:
-                            type: string
-                            example: ""
-                          value:
-                            type: string
-                            example: Hera
-                          hidden:
-                            type: boolean
-                            example: false
-                          advanced:
-                            type: boolean
-                            example: false
-                          group:
-                            type: string
-                            example: general
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            example: ScheduledLibraryUpdateInterval
-                          label:
-                            type: string
-                            example: Library scan interval
-                          summary:
-                            type: string
-                            example: ""
-                          type:
-                            type: string
-                            example: int
-                          default:
-                            type: integer
-                            format: int32
-                            example: 3600
-                          value:
-                            type: integer
-                            format: int32
-                            example: 3600
-                          hidden:
-                            type: boolean
-                            example: false
-                          advanced:
-                            type: boolean
-                            example: false
-                          group:
-                            type: string
-                            example: library
-                          enumValues:
-                            type: string
-                            example:
-                              900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
-                              hours|21600:every 6 hours|43200:every 12 hours|86400:daily
-                  example:
-                    - id: FriendlyName
-                      label: Friendly name
-                      summary:
-                        This name will be used to identify this media server to other computers
-                        on your network. If you leave it blank, your computer's name will
-                        be used instead.
-                      type: text
-                      default: ""
-                      value: Hera
-                      hidden: false
-                      advanced: false
-                      group: general
-                    - id: ScheduledLibraryUpdateInterval
-                      label: Library scan interval
-                      summary: ""
-                      type: int
-                      default: 3600
-                      value: 3600
-                      hidden: false
-                      advanced: false
-                      group: library
-                      enumValues:
-                        900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
-                        hours|21600:every 6 hours|43200:every 12 hours|86400:daily
+          schema:
+            type: object
+            properties:
+              MediaContainer:
+                type: object
+                properties:
+                  size:
+                    type: integer
+                    format: int32
+                    example: 161
+                  Setting:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              example: FriendlyName
+                            label:
+                              type: string
+                              example: Friendly name
+                            summary:
+                              type: string
+                              example:
+                                This name will be used to identify this media server to other computers
+                                on your network. If you leave it blank, your computer's name
+                                will be used instead.
+                            type:
+                              type: string
+                              example: text
+                            default:
+                              type: string
+                              example: ""
+                            value:
+                              type: string
+                              example: Hera
+                            hidden:
+                              type: boolean
+                              example: false
+                            advanced:
+                              type: boolean
+                              example: false
+                            group:
+                              type: string
+                              example: general
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              example: ScheduledLibraryUpdateInterval
+                            label:
+                              type: string
+                              example: Library scan interval
+                            summary:
+                              type: string
+                              example: ""
+                            type:
+                              type: string
+                              example: int
+                            default:
+                              type: integer
+                              format: int32
+                              example: 3600
+                            value:
+                              type: integer
+                              format: int32
+                              example: 3600
+                            hidden:
+                              type: boolean
+                              example: false
+                            advanced:
+                              type: boolean
+                              example: false
+                            group:
+                              type: string
+                              example: library
+                            enumValues:
+                              type: string
+                              example:
+                                900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
+                                hours|21600:every 6 hours|43200:every 12 hours|86400:daily
+                    example:
+                      - id: FriendlyName
+                        label: Friendly name
+                        summary:
+                          This name will be used to identify this media server to other computers
+                          on your network. If you leave it blank, your computer's name will
+                          be used instead.
+                        type: text
+                        default: ""
+                        value: Hera
+                        hidden: false
+                        advanced: false
+                        group: general
+                      - id: ScheduledLibraryUpdateInterval
+                        label: Library scan interval
+                        summary: ""
+                        type: int
+                        default: 3600
+                        value: 3600
+                        hidden: false
+                        advanced: false
+                        group: library
+                        enumValues:
+                          900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
+                          hours|21600:every 6 hours|43200:every 12 hours|86400:daily
 
     "400":
       $ref: "../../responses/400.yaml"


### PR DESCRIPTION
## Intent
Updating the pms/paths/metadata.yaml file to add a 200 response format for the getMetadata endpoint.

## Testing
I've documented my testing set up by generating a Ruby SDK [here](https://gist.github.com/johnhebron/3c6779b1d10d29015013e2fd03db2360).

For this PR, the Ruby test code was:
```
libraries = api_instance.get_metadata(17)
```

**Before, response data was nil:**
<img width="1280" alt="Screenshot 2024-01-19 at 7 42 13 PM" src="https://github.com/LukeHagar/plex-api-spec/assets/7632624/a6160714-1c44-49c5-ab3e-d62ee8c4d885">


**After, response data is present:**
<img width="1280" alt="Screenshot 2024-01-19 at 7 42 32 PM" src="https://github.com/LukeHagar/plex-api-spec/assets/7632624/8b52cb65-29ff-484c-abf1-be10a8492229">
