### PR TITLE
Updating Paylists [POST] to reflect that URI is required

### DIFF
--- a/pms/paths/playlists.yaml
+++ b/pms/paths/playlists.yaml
@@ -38,7 +38,7 @@ post:
       in: query
       schema:
         type: string
-      required: false
+      required: true
     - name: playQueueID
       description: the play queue to copy to a playlist
       in: query

--- a/pms/paths/server-preferences.yaml
+++ b/pms/paths/server-preferences.yaml
@@ -9,112 +9,113 @@ get:
       description: Server Preferences
       content:
         application/json:
-          type: object
-          properties:
-            MediaContainer:
-              type: object
-              properties:
-                size:
-                  type: integer
-                  format: int32
-                  example: 161
-                Setting:
-                  type: array
-                  items:
-                    oneOf:
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            example: FriendlyName
-                          label:
-                            type: string
-                            example: Friendly name
-                          summary:
-                            type: string
-                            example:
-                              This name will be used to identify this media server to other computers
-                              on your network. If you leave it blank, your computer's name
-                              will be used instead.
-                          type:
-                            type: string
-                            example: text
-                          default:
-                            type: string
-                            example: ""
-                          value:
-                            type: string
-                            example: Hera
-                          hidden:
-                            type: boolean
-                            example: false
-                          advanced:
-                            type: boolean
-                            example: false
-                          group:
-                            type: string
-                            example: general
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            example: ScheduledLibraryUpdateInterval
-                          label:
-                            type: string
-                            example: Library scan interval
-                          summary:
-                            type: string
-                            example: ""
-                          type:
-                            type: string
-                            example: int
-                          default:
-                            type: integer
-                            format: int32
-                            example: 3600
-                          value:
-                            type: integer
-                            format: int32
-                            example: 3600
-                          hidden:
-                            type: boolean
-                            example: false
-                          advanced:
-                            type: boolean
-                            example: false
-                          group:
-                            type: string
-                            example: library
-                          enumValues:
-                            type: string
-                            example:
-                              900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
-                              hours|21600:every 6 hours|43200:every 12 hours|86400:daily
-                  example:
-                    - id: FriendlyName
-                      label: Friendly name
-                      summary:
-                        This name will be used to identify this media server to other computers
-                        on your network. If you leave it blank, your computer's name will
-                        be used instead.
-                      type: text
-                      default: ""
-                      value: Hera
-                      hidden: false
-                      advanced: false
-                      group: general
-                    - id: ScheduledLibraryUpdateInterval
-                      label: Library scan interval
-                      summary: ""
-                      type: int
-                      default: 3600
-                      value: 3600
-                      hidden: false
-                      advanced: false
-                      group: library
-                      enumValues:
-                        900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
-                        hours|21600:every 6 hours|43200:every 12 hours|86400:daily
+          schema:
+            type: object
+            properties:
+              MediaContainer:
+                type: object
+                properties:
+                  size:
+                    type: integer
+                    format: int32
+                    example: 161
+                  Setting:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              example: FriendlyName
+                            label:
+                              type: string
+                              example: Friendly name
+                            summary:
+                              type: string
+                              example:
+                                This name will be used to identify this media server to other computers
+                                on your network. If you leave it blank, your computer's name
+                                will be used instead.
+                            type:
+                              type: string
+                              example: text
+                            default:
+                              type: string
+                              example: ""
+                            value:
+                              type: string
+                              example: Hera
+                            hidden:
+                              type: boolean
+                              example: false
+                            advanced:
+                              type: boolean
+                              example: false
+                            group:
+                              type: string
+                              example: general
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              example: ScheduledLibraryUpdateInterval
+                            label:
+                              type: string
+                              example: Library scan interval
+                            summary:
+                              type: string
+                              example: ""
+                            type:
+                              type: string
+                              example: int
+                            default:
+                              type: integer
+                              format: int32
+                              example: 3600
+                            value:
+                              type: integer
+                              format: int32
+                              example: 3600
+                            hidden:
+                              type: boolean
+                              example: false
+                            advanced:
+                              type: boolean
+                              example: false
+                            group:
+                              type: string
+                              example: library
+                            enumValues:
+                              type: string
+                              example:
+                                900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
+                                hours|21600:every 6 hours|43200:every 12 hours|86400:daily
+                    example:
+                      - id: FriendlyName
+                        label: Friendly name
+                        summary:
+                          This name will be used to identify this media server to other computers
+                          on your network. If you leave it blank, your computer's name will
+                          be used instead.
+                        type: text
+                        default: ""
+                        value: Hera
+                        hidden: false
+                        advanced: false
+                        group: general
+                      - id: ScheduledLibraryUpdateInterval
+                        label: Library scan interval
+                        summary: ""
+                        type: int
+                        default: 3600
+                        value: 3600
+                        hidden: false
+                        advanced: false
+                        group: library
+                        enumValues:
+                          900:every 15 minutes|1800:every 30 minutes|3600:hourly|7200:every 2
+                          hours|21600:every 6 hours|43200:every 12 hours|86400:daily
 
     "400":
       $ref: "../../responses/400.yaml"


### PR DESCRIPTION
Testing out the [POST] paylists endpoint and it seems that without a URI you can not create a playlist.

Attempting in PostMan without URI:
<img width="900" alt="Screenshot 2024-01-19 at 9 00 42 PM" src="https://github.com/LukeHagar/plex-api-spec/assets/7632624/d0254b5d-121c-43f1-83ab-bf55949ba786">

Attempting in PostMan with URI:
<img width="901" alt="Screenshot 2024-01-19 at 9 00 52 PM" src="https://github.com/LukeHagar/plex-api-spec/assets/7632624/ad611992-c0ab-44e3-b670-b18358e79c7f">

I verified the playlist was successfully created in Plex once the URI was included. 👍 