### PR TITLE
Updating type search for getContent

### DIFF
--- a/pms/paths/library-content-search.yaml
+++ b/pms/paths/library-content-search.yaml
@@ -1,0 +1,201 @@
+get:
+  tags:
+    - Library
+  summary: Search Library Section Items
+  operationId: searchLibrarySectionItems
+  description: |
+    Search for content within a specific section of the library.
+
+    ### Types
+    Each type in the library comes with a set of filters and sorts, aiding in building dynamic media controls:
+
+    - **Type Object Attributes**:
+      - `type`: Metadata type (if standard Plex type).  
+      - `title`: Title for this content type (e.g., "Movies").
+
+    - **Filter Objects**:
+      - Subset of the media query language.
+      - Attributes include `filter` (name), `filterType` (data type), `key` (endpoint for value range), and `title`.
+
+    - **Sort Objects**:
+      - Description of sort fields.
+      - Attributes include `defaultDirection` (asc/desc), `descKey` and `key` (sort parameters), and `title`.
+
+    > **Note**: Filters and sorts are optional; without them, no filtering controls are rendered.
+  parameters:
+    - name: sectionId
+      in: path
+      required: true
+      description: the Id of the library to query
+      schema:
+        type: integer
+    - name: type
+      description: Plex content type to search for
+      in: query
+      schema:
+        type: integer
+        enum:
+          - 1
+          - 2
+          - 3
+          - 4
+      required: true
+  responses:
+    "200":
+      description: The contents of the library by section and type
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              MediaContainer:
+                type: object
+                properties:
+                  size:
+                    type: integer
+                    format: int32
+                    example: 2
+                  allowSync:
+                    type: boolean
+                    example: false
+                  art:
+                    type: string
+                    example: /:/resources/show-fanart.jpg
+                  identifier:
+                    type: string
+                    example: com.plexapp.plugins.library
+                  mediaTagPrefix:
+                    type: string
+                    example: /system/bundle/media/flags/
+                  mediaTagVersion:
+                    type: integer
+                    format: int32
+                    example: 1698860922
+                  nocache:
+                    type: boolean
+                    example: true
+                  thumb:
+                    type: string
+                    example: /:/resources/show.png
+                  title1:
+                    type: string
+                    example: TV Shows
+                  title2:
+                    type: string
+                    example: Search for ''
+                  viewGroup:
+                    type: string
+                    example: season
+                  viewMode:
+                    type: integer
+                    format: int32
+                    example: 65593
+                  Metadata:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        ratingKey:
+                          type: string
+                          example: "2"
+                        key:
+                          type: string
+                          example: /library/metadata/2/children
+                        parentRatingKey:
+                          type: string
+                          example: "1"
+                        guid:
+                          type: string
+                          example: plex://season/602e67e766dfdb002c0a1b5b
+                        parentGuid:
+                          type: string
+                          example: plex://show/5d9c086c7d06d9001ffd27aa
+                        parentStudio:
+                          type: string
+                          example: Mutant Enemy Productions
+                        type:
+                          type: string
+                          example: season
+                        title:
+                          type: string
+                          example: Season 1
+                        parentKey:
+                          type: string
+                          example: /library/metadata/1
+                        parentTitle:
+                          type: string
+                          example: Firefly
+                        summary:
+                          type: string
+                          example: Captain Malcolm 'Mal' Reynolds is a former galactic war veteran who is
+                            the captain of the transport ship "Serenity". Mal and his crew,
+                            ensign Zoe Alleyne Washburne; Zoe's husband, pilot Hoban 'Wash'
+                            Washburne; muscular mercenary Jayne Cobb; young mechanic Kaylee
+                            Frye; former Alliance medical officer Simon Tam; his disturbed
+                            teenage sister River (both on the run from the interplanetary
+                            government "The Alliance"); the beautiful courtesan Inara Serra;
+                            and preacher Shepherd Book do any jobs, legal or illegal, they
+                            can find as the Serenity crew travels across the outskirts of
+                            outer space.
+                        index:
+                          type: integer
+                          format: int32
+                          example: 1
+                        parentIndex:
+                          type: integer
+                          format: int32
+                          example: 1
+                        parentYear:
+                          type: integer
+                          format: int32
+                          example: 2002
+                        thumb:
+                          type: string
+                          example: /library/metadata/2/thumb/1705636920
+                        art:
+                          type: string
+                          example: /library/metadata/1/art/1705636920
+                        parentThumb:
+                          type: string
+                          example: /library/metadata/1/thumb/1705636920
+                        parentTheme:
+                          type: string
+                          example: /library/metadata/1/theme/1705636920
+                        addedAt:
+                          type: integer
+                          format: int32
+                          example: 1705636916
+                        updatedAt:
+                          type: integer
+                          format: int32
+                          example: 1705636920
+                    example:
+                      - ratingKey: "2"
+                        key: /library/metadata/2/children
+                        parentRatingKey: "1"
+                        guid: plex://season/602e67e766dfdb002c0a1b5b
+                        parentGuid: plex://show/5d9c086c7d06d9001ffd27aa
+                        parentStudio: Mutant Enemy Productions
+                        type: season
+                        title: Season 1
+                        parentKey: /library/metadata/1
+                        parentTitle: Firefly
+                        summary: Captain Malcolm 'Mal' Reynolds is a former galactic war veteran who is
+                          the captain of the transport ship "Serenity". Mal and his crew,
+                          ensign Zoe Alleyne Washburne; Zoe's husband, pilot Hoban 'Wash'
+                          Washburne; muscular mercenary Jayne Cobb; young mechanic Kaylee
+                          Frye; former Alliance medical officer Simon Tam; his disturbed
+                          teenage sister River (both on the run from the interplanetary
+                          government "The Alliance"); the beautiful courtesan Inara Serra;
+                          and preacher Shepherd Book do any jobs, legal or illegal, they can
+                          find as the Serenity crew travels across the outskirts of outer
+                          space.
+                        index: 1
+                        parentIndex: 1
+                        parentYear: 2002
+                        thumb: /library/metadata/2/thumb/1705636920
+                        art: /library/metadata/1/art/1705636920
+                        parentThumb: /library/metadata/1/thumb/1705636920
+                        parentTheme: /library/metadata/1/theme/1705636920
+                        addedAt: 1705636916
+                        updatedAt: 1705636920

--- a/pms/paths/library-content-search.yaml
+++ b/pms/paths/library-content-search.yaml
@@ -1,8 +1,8 @@
 get:
   tags:
     - Library
-  summary: Search Library Section Items
-  operationId: searchLibrarySectionItems
+  summary: Search Library
+  operationId: searchLibrary
   description: |
     Search for content within a specific section of the library.
 

--- a/pms/paths/library-content.yaml
+++ b/pms/paths/library-content.yaml
@@ -24,7 +24,10 @@ get:
     - `resolution`: Items categorized by resolution.
     - `firstCharacter`: Items categorized by the first letter.
     - `folder`: Items categorized by folder.
-    - `search?type=1`: Search functionality within the section.
+    - `search?type=1`: Search only (type=1) movies.
+    - `search?type=2`: Search only (type=2) shows.
+    - `search?type=3`: Search only (type=3) seasons.
+    - `search?type=4`: Search only (type=4) episodes.
   parameters:
     - name: sectionId
       in: path
@@ -59,6 +62,9 @@ get:
           - firstCharacter
           - folder
           - search?type=1
+          - search?type=2
+          - search?type=3
+          - search?type=4
   responses:
     "200":
       description: The contents of the library by section and tag

--- a/pms/paths/library-content.yaml
+++ b/pms/paths/library-content.yaml
@@ -24,10 +24,6 @@ get:
     - `resolution`: Items categorized by resolution.
     - `firstCharacter`: Items categorized by the first letter.
     - `folder`: Items categorized by folder.
-    - `search?type=1`: Search only (type=1) movies.
-    - `search?type=2`: Search only (type=2) shows.
-    - `search?type=3`: Search only (type=3) seasons.
-    - `search?type=4`: Search only (type=4) episodes.
   parameters:
     - name: sectionId
       in: path
@@ -61,10 +57,6 @@ get:
           - resolution
           - firstCharacter
           - folder
-          - search?type=1
-          - search?type=2
-          - search?type=3
-          - search?type=4
   responses:
     "200":
       description: The contents of the library by section and tag

--- a/pms/pms-spec.yaml
+++ b/pms/pms-spec.yaml
@@ -91,6 +91,8 @@ paths:
     $ref: "./paths/library-content.yaml"
   /library/sections/{sectionId}/refresh:
     $ref: "./paths/library-refresh.yaml"
+  /library/sections/{sectionId}/search:
+    $ref: "./paths/library-content-search.yaml"
 
   # /library/sections/{sectionId}/common:
   #   $ref: "./paths/library-content-common.yaml"


### PR DESCRIPTION
Playing around with `/library/sections/:sectionId` and in the returned Directory it shows the different type searches. I've updated the client to accept all four that I'm aware of.

- `search?type=1`: Search only (type=1) movies.
- `search?type=2`: Search only (type=2) shows.
- `search?type=3`: Search only (type=3) seasons.
- `search?type=4`: Search only (type=4) episodes.


Response Directory:
```
{
    "prompt": "Search for Shows",
    "search": true,
    "key": "search?type=2",
    "title": "Search Shows..."
},
{
    "prompt": "Search for Episodes",
    "search": true,
    "key": "search?type=4",
    "title": "Search Episodes..."
}
```