### PR TITLE
add plex metadata spec and watchlist api

### DIFF
--- a/metadata/paths/watchlist.yaml
+++ b/metadata/paths/watchlist.yaml
@@ -1,0 +1,134 @@
+get:
+  tags:
+    - Metadata
+  summary: Get User Watchlist
+  description: Get User Watchlist
+  operationId: getWatchlist
+  parameters:
+    - name: X-Plex-Token
+      description: User Token
+      in: query
+      required: true
+      schema:
+        type: string
+  responses:
+    "200":
+      description: Watchlist Data
+      content:
+        application/json:
+          schema:
+            type: object
+              properties:
+                librarySectionID:
+                  type: string
+                librarySectionTitle:
+                  type: string
+                offset:
+                  type: integer
+                  format: int32
+                totalSize:
+                  type: integer
+                  format: int32
+                identifier:
+                  type: string
+                size:
+                  type: integer
+                  format: int32
+                Metadata:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      art:
+                        type: string
+                      guid:
+                        type: string
+                      key:
+                        type: string
+                      ratingKey:
+                        type: string
+                      studio:
+                        type: string
+                      tagline:
+                        type: string
+                      type:
+                        type: string
+                      thumb:
+                        type: string
+                      addedAt:
+                        type: integer
+                        format: int32
+                      duration:
+                        type: integer
+                        format: int32
+                      publicPagesURL:
+                        type: string
+                      slug:
+                        type: string
+                      userState:
+                        type: boolean
+                      title:
+                        type: string
+                      contentRating:
+                        type: string
+                      originallyAvailableAt:
+                        type: string
+                        format: date
+                      year:
+                        type: integer
+                        format: int32
+                      Image:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            alt:
+                              type: string
+                            type:
+                              type: string
+                            url:
+                              type: string
+                      banner:
+                        type: string
+                      rating:
+                        type: number
+                      expiresAt:
+                        type: integer
+                        format: int32
+                      originalTitle:
+                        type: string
+                      audienceRating:
+                        type: number
+                      audienceRatingImage:
+                        type: string
+                      ratingImage:
+                        type: string
+                      imdbRatingCount:
+                        type: integer
+                        format: int32
+                      subtype:
+                        type: string
+                      theme:
+                        type: string
+                      leafCount:
+                        type: integer
+                        format: int32
+                      childCount:
+                        type: integer
+                        format: int32
+                      isContinuingSeries:
+                        type: boolean
+                      skipChildren:
+                        type: boolean
+                      availabilityId:
+                        type: string
+                      streamingMediaId:
+                        type: string
+                      playableKey:
+                        type: string
+
+
+    "400":
+      $ref: "../../responses/400.yaml"
+    "401":
+      $ref: "../../responses/401.yaml"

--- a/metadata/plex-metadata.yaml
+++ b/metadata/plex-metadata.yaml
@@ -1,0 +1,32 @@
+openapi: 3.1.0
+info:
+  title: Plex-Metadata-API
+  summary: A Plex Metadata API Map
+  description: An Open API Spec for interacting with metadata.provider.plex.tv
+  version: 0.0.3
+  contact:
+    name: Luke Hagar
+    url: "https://www.LukeHagar.com"
+    email: Lukeslakemail@gmail.com
+  license:
+    name: MIT
+    identifier: MIT
+
+servers:
+  - url: "https://metadata.provider.plex.tv"
+    description: The plex metadata provider server
+
+security:
+  - accessToken: []
+
+components:
+  securitySchemes:
+    accessToken:
+      description: Plex Authentication Token
+      type: apiKey
+      in: header
+      name: X-Plex-Token
+
+paths:
+  /library/sections/watchlist/{filter}:
+    $ref: "./paths/watchlist.yaml"


### PR DESCRIPTION
Add plex metadata spec and watchlist api

> [!NOTE]
> I don't use openapi much, so apologies if this is the wrong approach. Happy to tweak/rework as requested.

It felt like this is a separate spec (similar to the plextv breakout), so I created a new spec containing just the `/library/sections/watchlist/{filter}` call.

- I'm unsure how to call out the different filters, I believe these might be similar to the history filters from the PMS spec, but I haven't tested them much. I generally just use `all`. I'll see if I can look up the others and add them
- I don't use it in my code, but I assume this call supports the `size` and `start` headers to page through the data, I can add those if you like
- This is currently designed to allow you to pass a user token to the call so that an app can lookup the watchlist for its users. 
