### PR TITLE
Changing postal_code data type to string.

### DIFF
--- a/paths/pins/pins.yaml
+++ b/paths/pins/pins.yaml
@@ -70,7 +70,7 @@ post:
                     type: string
                     example: America/Chicago
                   postal_code:
-                    type: number
+                    type: string
                     example: 78732
                   in_privacy_restricted_country:
                     type: boolean

--- a/plextv/paths/pins-id.yaml
+++ b/plextv/paths/pins-id.yaml
@@ -65,7 +65,7 @@ get:
                     type: string
                     example: America/Chicago
                   postal_code:
-                    type: number
+                    type: string
                     example: 78732
                   in_privacy_restricted_country:
                     type: boolean

--- a/plextv/paths/pins.yaml
+++ b/plextv/paths/pins.yaml
@@ -69,7 +69,7 @@ post:
                     type: string
                     example: America/Chicago
                   postal_code:
-                    type: number
+                    type: string
                     example: 78732
                   in_privacy_restricted_country:
                     type: boolean


### PR DESCRIPTION
Data type returned from Plex is string, and in some countries the postal_code contains spaces ("811 06" in Slovakia) or string characters ("SW1A 1AA" in UK).