### PR TITLE
Add X-Plex-Product header for pin call

### DIFF
--- a/parameters/ClientProduct.yaml
+++ b/parameters/ClientProduct.yaml
@@ -1,0 +1,8 @@
+name: X-Plex-Product
+description: |
+  Product name of the application shown in the list of devices
+in: header
+schema:
+  type: string
+  example: Postman
+required: true

--- a/paths/pins/pins.yaml
+++ b/paths/pins/pins.yaml
@@ -19,6 +19,7 @@ post:
         default: false
       required: false
     - $ref: "../../parameters/ClientIdentifier.yaml"
+    - $ref: "../../parameters/ClientProduct.yaml"
   responses:
     "201":
       description: The Pin


### PR DESCRIPTION
Calling https://plex.tv/api/v2/pins expects the X-Plex-Product header with name of the application (product) which wants to create the PIN.