### PR TITLE
Fix newRegistration type for pins endpoint

### DIFF
--- a/paths/pins/pins.yaml
+++ b/paths/pins/pins.yaml
@@ -96,8 +96,7 @@ post:
                 type: string
                 format: nullable
               newRegistration:
-                type: string
-                format: nullable
+                type: boolean
     "400":
       description: X-Plex-Client-Identifier is missing
       content:


### PR DESCRIPTION
I'm using the Go SDK, and whenever I tried to get the token, I was getting the following error: `Error: error unmarshalling json response body: json: cannot unmarshal bool into Go value of type string`. I downloaded the SDK code and changed the `NewRegistration` type to bool, and it works now. I assume it's the place where the type should be changed.