### PR TITLE
Fix newRegistration type for pins-id endpoint

### DIFF
--- a/paths/pins/pins-id.yaml
+++ b/paths/pins/pins-id.yaml
@@ -91,8 +91,7 @@ get:
                 type: string
                 format: nullable
               newRegistration:
-                type: string
-                format: nullable
+                type: [boolean, "null"]
     "400":
       description: X-Plex-Client-Identifier is missing
       content:


### PR DESCRIPTION
I found another `newRegistration` field which I forgot to include into #30. I checked and there are other `newRegistration`s of type `string` in `plextv` directory. Should the types be changed there as well?