### PR TITLE
removed the / from the url, this caused incorrect urls in the SDK's

### DIFF
--- a/src/models/PlexDevice.yaml
+++ b/src/models/PlexDevice.yaml
@@ -101,6 +101,7 @@ properties:
         - IPv6
       properties:
         protocol:
+          # TODO - This should be an enum but there is a bug in the generator
           description: The protocol used for the connection (http, https, etc)
           example: "http"
           type: string

--- a/src/models/PlexDevice.yaml
+++ b/src/models/PlexDevice.yaml
@@ -102,10 +102,8 @@ properties:
       properties:
         protocol:
           description: The protocol used for the connection (http, https, etc)
+          example: "http"
           type: string
-          enum:
-            - http
-            - https
         address:
           description: The (ip) address or domain name used for the connection
           type: string

--- a/src/models/UserPlexAccount.yaml
+++ b/src/models/UserPlexAccount.yaml
@@ -232,10 +232,10 @@ properties:
     description: If you are subscribed to the Plex newsletter
     default: false
   mailingListStatus:
-    description: Your current mailing list status
-    enum:
-      - active
-      - unsubscribed
+    # TODO - This should be an enum but there is a bug in the generator
+    description: Your current mailing list status (active or unsubscribed)
+    type: string
+    example: subscribed
   maxHomeSize:
     type: integer
     description: The maximum number of accounts allowed in the Plex Home

--- a/src/paths/companions/companions.yaml
+++ b/src/paths/companions/companions.yaml
@@ -1,6 +1,6 @@
 get:
   servers:
-    - url: https://plex.tv/api/v2/
+    - url: https://plex.tv/api/v2
   tags:
     - Plex
   summary: Get Companions Data

--- a/src/paths/friends/friends.yaml
+++ b/src/paths/friends/friends.yaml
@@ -1,6 +1,6 @@
 get:
   servers:
-    - url: https://plex.tv/api/v2/
+    - url: https://plex.tv/api/v2
   tags:
     - Plex
   summary: Get list of friends of the user logged in

--- a/src/paths/geoip/geoip.yaml
+++ b/src/paths/geoip/geoip.yaml
@@ -1,6 +1,6 @@
 get:
   servers:
-    - url: https://plex.tv/api/v2/
+    - url: https://plex.tv/api/v2
   security: [] # No security required
   tags:
     - Plex

--- a/src/paths/pins/pins-id.yaml
+++ b/src/paths/pins/pins-id.yaml
@@ -1,6 +1,6 @@
 get:
   servers:
-    - url: https://plex.tv/api/v2/
+    - url: https://plex.tv/api/v2
   security: [] # No security required
   tags:
     - Plex

--- a/src/paths/pins/pins.yaml
+++ b/src/paths/pins/pins.yaml
@@ -1,6 +1,6 @@
 post:
   servers:
-    - url: https://plex.tv/api/v2/
+    - url: https://plex.tv/api/v2
   tags:
     - Plex
   summary: Get a Pin

--- a/src/paths/resources/get-server-resources.yaml
+++ b/src/paths/resources/get-server-resources.yaml
@@ -1,6 +1,6 @@
 get:
   servers:
-    - url: https://plex.tv/api/v2/
+    - url: https://plex.tv/api/v2
   tags:
     - Plex
   summary: Get Server Resources

--- a/src/paths/user/get-user-data-by-token.yaml
+++ b/src/paths/user/get-user-data-by-token.yaml
@@ -1,6 +1,6 @@
 get:
   servers:
-    - url: https://plex.tv/api/v2/
+    - url: https://plex.tv/api/v2
   tags:
     - Authentication
   summary: Get Token Details

--- a/src/paths/users/post-sign-in.yaml
+++ b/src/paths/users/post-sign-in.yaml
@@ -1,6 +1,6 @@
 post:
   servers:
-    - url: https://plex.tv/api/v2/
+    - url: https://plex.tv/api/v2
   security: []
   tags:
     - Authentication


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `protocol` property in the PlexDevice configuration to allow more flexibility with example values.
  
- **Bug Fixes**
	- Modified API endpoint URLs to remove the trailing slash, ensuring compatibility with server request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->