### PR TITLE
fix: incorrect casing for timespan

### DIFF
--- a/src/paths/statistics/bandwidth.yaml
+++ b/src/paths/statistics/bandwidth.yaml
@@ -5,7 +5,7 @@ get:
   description: This will return the bandwidth statistics for the server
   operationId: getBandwidthStatistics
   parameters:
-    - name: Timespan
+    - name: timespan
       description: |
         The timespan to retrieve statistics for
         the exact meaning of this parameter is not known

--- a/src/paths/statistics/media.yaml
+++ b/src/paths/statistics/media.yaml
@@ -5,7 +5,7 @@ get:
   description: This will return the media statistics for the server
   operationId: getStatistics
   parameters:
-    - name: Timespan
+    - name: timespan
       description: |
         The timespan to retrieve statistics for
         the exact meaning of this parameter is not known

--- a/src/paths/statistics/resources.yaml
+++ b/src/paths/statistics/resources.yaml
@@ -5,7 +5,7 @@ get:
   description: This will return the resources for the server
   operationId: getResourcesStatistics
   parameters:
-    - name: Timespan
+    - name: timespan
       description: |
         The timespan to retrieve statistics for
         the exact meaning of this parameter is not known


### PR DESCRIPTION
Just a quick fix to correct the casing of the parameter timespan, as plex is case sensitive and will ignore these params.