### PR TITLE
fix: add support for albums and tracks

### DIFF
--- a/src/models/common/PlexMediaType.yaml
+++ b/src/models/common/PlexMediaType.yaml
@@ -5,6 +5,8 @@ enum:
   - 3
   - 4
   - 8
+  - 9
+  - 10
 example: 2
 x-speakeasy-enums:
   - MOVIE
@@ -12,3 +14,5 @@ x-speakeasy-enums:
   - SEASON
   - EPISODE
   - AUDIO
+  - ALBUM
+  - TRACK

--- a/src/paths/library/[sectionKey]/get-library-items.yaml
+++ b/src/paths/library/[sectionKey]/get-library-items.yaml
@@ -24,6 +24,7 @@ get:
     - `resolution`: Items categorized by resolution.
     - `firstCharacter`: Items categorized by the first letter.
     - `folder`: Items categorized by folder.
+    - `albums`: Items categorized by album.
   parameters:
     - name: tag
       in: path
@@ -51,6 +52,7 @@ get:
           - resolution
           - firstCharacter
           - folder
+          - albums
     - name: includeGuids
       in: query
       description: |


### PR DESCRIPTION
This PR adds support for the `albums` tag, album `9` media type, and track `10` media type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded media type options with new enumerations: `9`, `10`, `ALBUM`, and `TRACK`.
	- Added a new filtering option for the `get-library-items` API to allow users to filter by `albums`.

- **Documentation**
	- Updated API descriptions to include new filtering options for enhanced user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->