### PR TITLE
fix: Add additional titles and indexes to item metadata

### DIFF
--- a/src/paths/library/metadata/[ratingKey]/get-meta-data-by-rating-key.yaml
+++ b/src/paths/library/metadata/[ratingKey]/get-meta-data-by-rating-key.yaml
@@ -93,6 +93,12 @@ get:
                         originalTitle:
                           type: string
                           description: The name of the artist for the track when audio.
+                        index:
+                          type: integer
+                          description: The track number when audio, and the episode number when video.
+                        parentIndex:
+                          type: integer
+                          description: The disc number when audio, and the season number when video.
                         contentRating:
                           type: string
                           example: PG-13

--- a/src/paths/library/metadata/[ratingKey]/get-meta-data-by-rating-key.yaml
+++ b/src/paths/library/metadata/[ratingKey]/get-meta-data-by-rating-key.yaml
@@ -86,10 +86,13 @@ get:
                           example: /library/sections/1
                         grandparentTitle:
                           type: string
+                          description: The name of the album artist for the track when audio, and the name of the TV show for the episode when video.
                         parentTitle:
                           type: string
+                          description: The name of the album for the track when audio, and the name of the season for the episode when video.
                         originalTitle:
                           type: string
+                          description: The name of the artist for the track when audio.
                         contentRating:
                           type: string
                           example: PG-13

--- a/src/paths/library/metadata/[ratingKey]/get-meta-data-by-rating-key.yaml
+++ b/src/paths/library/metadata/[ratingKey]/get-meta-data-by-rating-key.yaml
@@ -84,6 +84,12 @@ get:
                         librarySectionKey:
                           type: string
                           example: /library/sections/1
+                        grandparentTitle:
+                          type: string
+                        parentTitle:
+                          type: string
+                        originalTitle:
+                          type: string
                         contentRating:
                           type: string
                           example: PG-13

--- a/src/paths/library/metadata/[ratingKey]/get-meta-data-by-rating-key.yaml
+++ b/src/paths/library/metadata/[ratingKey]/get-meta-data-by-rating-key.yaml
@@ -89,16 +89,16 @@ get:
                           description: The name of the album artist for the track when audio, and the name of the TV show for the episode when video.
                         parentTitle:
                           type: string
-                          description: The name of the album for the track when audio, and the name of the season for the episode when video.
+                          description: The name of the album for the track when audio, and the name of the season for the episode when TV show.
                         originalTitle:
                           type: string
-                          description: The name of the artist for the track when audio.
+                          description: The orginal untranslated name of the media item when non-english.
                         index:
                           type: integer
-                          description: The track number when audio, and the episode number when video.
+                          description: The index starting from 0 of this media item in the MetaData array.
                         parentIndex:
                           type: integer
-                          description: The disc number when audio, and the season number when video.
+                          description: The parent index starting from 0 of this media item in the parent MetaData array.
                         contentRating:
                           type: string
                           example: PG-13


### PR DESCRIPTION
This PR adds support for the `grandparentTitle`, `parentTitle`, `originalTitle`, `index`, and `parentIndex` item metadata fields. The example is from a non-hierarchical library, so adding example values wouldn't match the existing example data.

Example:

```diff
{
  "MediaContainer": {
    "size": 1,
    "allowSync": true,
    "identifier": "com.plexapp.plugins.library",
    "librarySectionID": 4,
    "librarySectionTitle": "Music",
    "librarySectionUUID": "3c088ca3-5a22-4ab0-a5f6-96172580433e",
    "mediaTagPrefix": "/system/bundle/media/flags/",
    "mediaTagVersion": 1730230381,
    "Metadata": [
      {
        "ratingKey": "3013",
        "key": "/library/metadata/3013",
        "parentRatingKey": "3008",
        "grandparentRatingKey": "3007",
        "guid": "plex://track/5d0802d7403c640290f88cb3",
        "parentGuid": "plex://album/5d07cbed403c640290e32974",
        "grandparentGuid": "plex://artist/5d07bcb4403c64029053da80",
        "parentStudio": "Atlantic",
        "type": "track",
        "title": "Screwed",
        "grandparentKey": "/library/metadata/3007",
        "parentKey": "/library/metadata/3008",
        "librarySectionTitle": "Music",
        "librarySectionID": 4,
        "librarySectionKey": "/library/sections/4",
+       "grandparentTitle": "Janelle Monáe",
+       "parentTitle": "Dirty Computer",
+       "originalTitle": "Janelle Monáe ft. Zoë Kravitz",
        "summary": "",
+       "index": 5,
+       "parentIndex": 1,
        "ratingCount": 8623,
        "viewCount": 33,
        "lastViewedAt": 1702820467,
        "parentYear": 2018,
        "thumb": "/library/metadata/3008/thumb/1717555188",
        "art": "/library/metadata/3007/art/1731300415",
        "parentThumb": "/library/metadata/3008/thumb/1717555188",
        "grandparentThumb": "/library/metadata/3007/thumb/1731300415",
        "grandparentArt": "/library/metadata/3007/art/1731300415",
        "duration": 302491,
        "addedAt": 1525097811,
        "updatedAt": 1731300416,
        "musicAnalysisVersion": "1",
        "Media": [
          {
            "id": 5019,
            "duration": 302491,
            "bitrate": 1650,
            "audioChannels": 2,
            "audioCodec": "flac",
            "container": "flac",
            "hasVoiceActivity": false,
            "Part": [
              {
                "accessible": true,
                "exists": true,
                "id": 8862,
                "key": "/library/parts/8862/1641607904/file.flac",
                "duration": 302491,
                "file": "/media/Music/Janelle Monáe/Dirty Computer/05. Screwed.flac",
                "size": 62930454,
                "container": "flac",
                "hasThumbnail": "1",
                "Stream": [
                  {
                    "id": 17528,
                    "streamType": 2,
                    "selected": true,
                    "codec": "flac",
                    "index": 0,
                    "channels": 2,
                    "bitrate": 1650,
                    "albumGain": "-9.13",
                    "albumPeak": "1.000000",
                    "albumRange": "8.868684",
                    "audioChannelLayout": "stereo",
                    "bitDepth": 24,
                    "gain": "-9.13",
                    "loudness": "-8.87",
                    "lra": "5.80",
                    "peak": "0.993688",
                    "samplingRate": 44100,
                    "displayTitle": "FLAC (Stereo)",
                    "extendedDisplayTitle": "FLAC (Stereo)"
                  },
                  {
                    "id": 71824,
                    "key": "/library/streams/71824",
                    "streamType": 4,
                    "codec": "lrc",
                    "format": "lrc",
                    "minLines": "3",
                    "provider": "com.plexapp.agents.lyricfind",
                    "timed": "1",
                    "displayTitle": "LRC",
                    "extendedDisplayTitle": "LRC (External)"
                  }
                ]
              }
            ]
          }
        ],
        "Image": [
          {
            "alt": "Screwed",
            "type": "coverPoster",
            "url": "/library/metadata/3008/thumb/1717555188"
          },
          {
            "alt": "Screwed",
            "type": "background",
            "url": "/library/metadata/3007/art/1731300415"
          }
        ],
        "Genre": [
          {
            "id": 24810,
            "filter": "genre=24810",
            "tag": "R&b"
          }
        ],
        "Guid": [
          {
            "id": "mbid://f1f18c39-135b-42f9-a019-29663f5e1e4c"
          }
        ]
      }
    ]
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced metadata for library items with new properties: `grandparentTitle`, `parentTitle`, `originalTitle`, `index`, and `parentIndex`, providing more contextual information about hierarchical relationships and item organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->