### PR TITLE
fix: update the episode ordering enum values

### DIFF
--- a/src/models/MetaData.yaml
+++ b/src/models/MetaData.yaml
@@ -76,18 +76,18 @@ properties:
   showOrdering:
     type: string
     description: |
-      Setting that indicates the episode ordering for the show 
-      None = Library default, 
-      tmdbAiring = The Movie Database (Aired), 
-      aired = TheTVDB (Aired), 
-      dvd = TheTVDB (DVD), 
-      absolute = TheTVDB (Absolute)).
+      Setting that indicates the episode ordering for the show
+      None = Library default,
+      tmdbAiring = The Movie Database (Aired),
+      tvdbAiring = TheTVDB (Aired),
+      tvdbDvd = TheTVDB (DVD),
+      tvdbAbsolute = TheTVDB (Absolute)).
     enum:
       - None
       - tmdbAiring
-      - aired
-      - dvd
-      - absolute
+      - tvdbAiring
+      - tvdbDvd
+      - tvdbAbsolute
     x-speakeasy-enums:
       - NONE
       - TMDB_AIRING

--- a/src/models/MetaData.yaml
+++ b/src/models/MetaData.yaml
@@ -94,7 +94,7 @@ properties:
       - TVDB_AIRING
       - TVDB_DVD
       - TVDB_ABSOLUTE
-    example: dvd
+    example: tvdbDvd
   thumb:
     type: string
     example: /library/metadata/58683/thumb/1703239236

--- a/src/models/MetaData.yaml
+++ b/src/models/MetaData.yaml
@@ -91,9 +91,9 @@ properties:
     x-speakeasy-enums:
       - NONE
       - TMDB_AIRING
-      - AIRED
-      - DVD
-      - ABSOLUTE
+      - TVDB_AIRING
+      - TVDB_DVD
+      - TVDB_ABSOLUTE
     example: dvd
   thumb:
     type: string

--- a/tests/paths/library/[sectionKey]/get-library-items.spec.ts
+++ b/tests/paths/library/[sectionKey]/get-library-items.spec.ts
@@ -4521,7 +4521,7 @@ describe("GET /library/sections", () => {
             addedAt: 1604971385,
             updatedAt: 1605009080,
             flattenSeasons: "1",
-            showOrdering: "absolute",
+            showOrdering: "tvdbAbsolute",
             Image: [
               {
                 alt: "Naruto: Shippuden",
@@ -6115,7 +6115,7 @@ describe("GET /library/sections", () => {
             addedAt: 1604971385,
             updatedAt: 1605009080,
             flattenSeasons: "1",
-            showOrdering: "absolute",
+            showOrdering: "tvdbAbsolute",
             Image: [
               {
                 alt: "Naruto: Shippuden",


### PR DESCRIPTION
The enum values for episode ordering do not match those that are currently being returned from the api

example (field in the bottom right) 
<img width="1453" alt="image" src="https://github.com/user-attachments/assets/d4ecf1fb-625b-42ee-9a1e-a3dac0f8ee75">

This is resulting in some downstream apps crashing with errors like: `System.Exception: Unknown value tvdbAbsolute for enum GetLibraryItemsShowOrdering`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the `showOrdering` property in the metadata schema for clearer episode ordering options.

- **Tests**
  - Introduced multiple test cases for the `/library/sections` API endpoint to validate response structure and content under various query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->