### PR TITLE
Fix link to pms-spec.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following SDKs are generated from the OpenAPI Specification. They are automa
 
 ## Project Structure
 
-The main OpenAPI Specification is located in the root directory as [pms-spec.yaml](https://github.com/LukeHagar/plex-api-spec/blob/main/pms-spec.yaml). Which references 
+The main OpenAPI Specification is located in the root directory as [pms-spec.yaml](https://github.com/LukeHagar/plex-api-spec/blob/main/src/pms-spec.yaml). Which references 
 
 - [**/paths**](https://github.com/LukeHagar/plex-api-spec/tree/main/paths): The endpoints for the Plex Media Server API. Each endpoint is defined in a separate file.
 - [**/models**](https://github.com/LukeHagar/plex-api-spec/tree/main/models): The schema models used in the specification.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following SDKs are generated from the OpenAPI Specification. They are automa
 
 ## Project Structure
 
-The main OpenAPI Specification is located in the root directory as [pms-spec.yaml](https://github.com/LukeHagar/plex-api-spec/blob/main/src/pms-spec.yaml). Which references 
+The main OpenAPI Specification is located in the root directory as [pms-spec.yaml](https://github.com/LukeHagar/plex-api-spec/blob/main/src/pms-spec.yaml), which references the following directories:
 
 - [**/paths**](https://github.com/LukeHagar/plex-api-spec/tree/main/paths): The endpoints for the Plex Media Server API. Each endpoint is defined in a separate file.
 - [**/models**](https://github.com/LukeHagar/plex-api-spec/tree/main/models): The schema models used in the specification.


### PR DESCRIPTION
Fixes the link in the README from `blob/main/pms-spec.yaml` to `blob/main/src/pms-spec.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the path to the main OpenAPI Specification file for clarity.
	- Rephrased the introduction to the main specification file for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->