### PR TITLE
fix: remove duplicate imports that will lead to failed js builds

### DIFF
--- a/src/paths/library/get-search-all-libraries.yaml
+++ b/src/paths/library/get-search-all-libraries.yaml
@@ -7,7 +7,6 @@ get:
     Search the provided query across all library sections, or a single section, and return matches as hubs, split up by type.
   parameters:
     - $ref: "../../parameters/query.yaml"
-    - $ref: "../../parameters/plex/x-plex-identifier.yaml"
     - name: limit
       in: query
       required: false

--- a/src/paths/pins/pins-id.yaml
+++ b/src/paths/pins/pins-id.yaml
@@ -14,11 +14,6 @@ get:
       required: true
       schema:
         type: integer
-    - $ref: ../../parameters/plex/x-plex-identifier.yaml
-    - $ref: ../../parameters/plex/x-plex-product.yaml
-    - $ref: ../../parameters/plex/x-plex-device.yaml
-    - $ref: ../../parameters/plex/x-plex-version.yaml
-    - $ref: ../../parameters/plex/x-plex-platform.yaml
   responses:
     "200":
       description: The Pin with a non-null authToken when it has been verified by the user

--- a/src/paths/pins/pins.yaml
+++ b/src/paths/pins/pins.yaml
@@ -18,11 +18,6 @@ post:
         type: boolean
         default: false
       required: false
-    - $ref: ../../parameters/plex/x-plex-identifier.yaml
-    - $ref: ../../parameters/plex/x-plex-product.yaml
-    - $ref: ../../parameters/plex/x-plex-device.yaml
-    - $ref: ../../parameters/plex/x-plex-version.yaml
-    - $ref: ../../parameters/plex/x-plex-platform.yaml
 
   responses:
     "201":

--- a/src/paths/resources/get-server-resources.yaml
+++ b/src/paths/resources/get-server-resources.yaml
@@ -24,7 +24,6 @@ get:
       description: Include IPv6 entries in the results
       schema:
         $ref: "../../models/common/PlexBoolean.yaml"
-    - $ref: "../../parameters/plex/x-plex-identifier.yaml"
   responses:
     "200":
       description: List of Plex Devices. This includes Plex hosted servers and clients

--- a/src/paths/users/post-sign-in.yaml
+++ b/src/paths/users/post-sign-in.yaml
@@ -7,12 +7,6 @@ post:
   summary: Get User Sign In Data
   description: Sign in user with username and password and return user data with Plex authentication token
   operationId: post-users-sign-in-data
-  parameters:
-    - $ref: ../../parameters/plex/x-plex-identifier.yaml
-    - $ref: ../../parameters/plex/x-plex-product.yaml
-    - $ref: ../../parameters/plex/x-plex-device.yaml
-    - $ref: ../../parameters/plex/x-plex-version.yaml
-    - $ref: ../../parameters/plex/x-plex-platform.yaml
   requestBody:
     content:
       application/x-www-form-urlencoded:


### PR DESCRIPTION
This should resolve: https://github.com/LukeHagar/plexjs/issues/26

Certain headers were imported multiple times, leading to 

```bash
> tsc

src/funcs/authenticationPostUsersSignInData.ts:97:5 - error TS1117: An object literal cannot have multiple properties with the same name.

97     "X-Plex-Client-Identifier": encodeSimple(
       ~~~~~~~~~~~~~~~~~~~~~~~~~~

src/funcs/authenticationPostUsersSignInData.ts:102:5 - error TS1117: An object literal cannot have multiple properties with the same name.

102     "X-Plex-Device": encodeSimple(
        ~~~~~~~~~~~~~~~

src/funcs/authenticationPostUsersSignInData.ts:107:5 - error TS1117: An object literal cannot have multiple properties with the same name.

107     "X-Plex-Platform": encodeSimple(
        ~~~~~~~~~~~~~~~~~

src/funcs/authenticationPostUsersSignInData.ts:112:5 - error TS1117: An object literal cannot have multiple properties with the same name.

112     "X-Plex-Product": encodeSimple(
        ~~~~~~~~~~~~~~~~

src/funcs/authenticationPostUsersSignInData.ts:117:5 - error TS1117: An object literal cannot have multiple properties with the same name.

117     "X-Plex-Version": encodeSimple(
        ~~~~~~~~~~~~~~~~

src/funcs/libraryGetSearchAllLibraries.ts:84:5 - error TS1117: An object literal cannot have multiple properties with the same name.

84     "X-Plex-Client-Identifier": encodeSimple(
       ~~~~~~~~~~~~~~~~~~~~~~~~~~

src/funcs/plexGetPin.ts:93:5 - error TS1117: An object literal cannot have multiple properties with the same name.

93     "X-Plex-Client-Identifier": encodeSimple(
       ~~~~~~~~~~~~~~~~~~~~~~~~~~

src/funcs/plexGetPin.ts:98:5 - error TS1117: An object literal cannot have multiple properties with the same name.

98     "X-Plex-Device": encodeSimple(
       ~~~~~~~~~~~~~~~

src/funcs/plexGetPin.ts:103:5 - error TS1117: An object literal cannot have multiple properties with the same name.

103     "X-Plex-Platform": encodeSimple(
        ~~~~~~~~~~~~~~~~~

src/funcs/plexGetPin.ts:108:5 - error TS1117: An object literal cannot have multiple properties with the same name.

108     "X-Plex-Product": encodeSimple(
        ~~~~~~~~~~~~~~~~

src/funcs/plexGetPin.ts:113:5 - error TS1117: An object literal cannot have multiple properties with the same name.

113     "X-Plex-Version": encodeSimple(
        ~~~~~~~~~~~~~~~~

src/funcs/plexGetServerResources.ts:91:5 - error TS1117: An object literal cannot have multiple properties with the same name.

91     "X-Plex-Client-Identifier": encodeSimple(
       ~~~~~~~~~~~~~~~~~~~~~~~~~~

src/funcs/plexGetTokenByPinId.ts:97:5 - error TS1117: An object literal cannot have multiple properties with the same name.

97     "X-Plex-Client-Identifier": encodeSimple(
       ~~~~~~~~~~~~~~~~~~~~~~~~~~

src/funcs/plexGetTokenByPinId.ts:102:5 - error TS1117: An object literal cannot have multiple properties with the same name.

102     "X-Plex-Device": encodeSimple(
        ~~~~~~~~~~~~~~~

src/funcs/plexGetTokenByPinId.ts:107:5 - error TS1117: An object literal cannot have multiple properties with the same name.

107     "X-Plex-Platform": encodeSimple(
        ~~~~~~~~~~~~~~~~~

src/funcs/plexGetTokenByPinId.ts:112:5 - error TS1117: An object literal cannot have multiple properties with the same name.

112     "X-Plex-Product": encodeSimple(
        ~~~~~~~~~~~~~~~~

src/funcs/plexGetTokenByPinId.ts:117:5 - error TS1117: An object literal cannot have multiple properties with the same name.

117     "X-Plex-Version": encodeSimple(
        ~~~~~~~~~~~~~~~~



```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new query parameters: `includeHttps`, `includeRelay`, and `includeIPv6` to the `get-server-resources` endpoint.
  
- **Bug Fixes**
	- Removed outdated parameter references related to Plex identifiers across multiple endpoints, including user sign-in and pin retrieval.

- **Documentation**
	- Updated OpenAPI specifications to reflect the changes in parameters for relevant endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->