### PR TITLE
fix: Add missing originalTitle property in responses

### DIFF
--- a/src/paths/status/sessions.yaml
+++ b/src/paths/status/sessions.yaml
@@ -77,7 +77,7 @@ get:
                           example: "1"
                         originalTitle:
                           type: string
-                          description: The orginal untranslated name of the media item when non-english, or the track artist if an audio Item has an album artist
+                          description: The original untranslated name of the media item when non-english, or the track artist if an audio Item has an album artist
                           example: The American Dream Is Killing Me
                         parentGuid:
                           type: string

--- a/src/paths/status/sessions.yaml
+++ b/src/paths/status/sessions.yaml
@@ -75,6 +75,10 @@ get:
                         musicAnalysisVersion:
                           type: string
                           example: "1"
+                        originalTitle:
+                          type: string
+                          description: The orginal untranslated name of the media item when non-english, or the track artist if an audio Item has an album artist
+                          example: The American Dream Is Killing Me
                         parentGuid:
                           type: string
                           example: plex://album/65394d6d472b8ab03ef47f12


### PR DESCRIPTION
@JasonLandbridge I see that `originalTitle` is already added (by you) [in the `Metadata` model](https://github.com/LukeHagar/plex-api-spec/blob/main/src/models/MetaData.yaml#L606) but it's unclear if this is not present in https://github.com/LukeHagar/plexjs due to npm publishing issues or because I'm misunderstanding how models vs. paths work here -- why doesn't the spec use the models in path responses, rather than hardcoding the responses for each path?

If I need to add `originalTitle` to other paths where Metadata is used I can add more commits, just confused about why its already in the spec but not used.

Fixes #72 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an `originalTitle` property in the session metadata, providing additional context for non-English media items or audio tracks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->