### PR TITLE
Update PlexMediaTypeString to match PlexMediaType

### DIFF
--- a/src/models/common/PlexMediaTypeString.yaml
+++ b/src/models/common/PlexMediaTypeString.yaml
@@ -4,6 +4,9 @@ enum:
   - show
   - season
   - episode
+  - artist
+  - album
+  - track
 example: "movie"
 description: |
   The type of media content
@@ -12,3 +15,6 @@ x-speakeasy-enums:
   - TV_SHOW
   - SEASON
   - EPISODE
+  - AUDIO
+  - ALBUM
+  - TRACK


### PR DESCRIPTION
GetLibraryItems fails on plexgo when using 
`operations.GetLibraryItemsQueryParamTypeTrack.ToPointer(),` due to  `error unmarshalling json response body: invalid value for GetLibraryItemsLibraryType: track`