### PR TITLE
added missing flattenSeason

### DIFF
--- a/src/models/MetaData.yaml
+++ b/src/models/MetaData.yaml
@@ -84,6 +84,7 @@ properties:
       - LIBRARY_DEFAULT
       - HIDE
       - SHOW
+    example: "1"
   episodeSort:
     type: string
     description: >-
@@ -97,6 +98,7 @@ properties:
       - LIBRARY_DEFAULT
       - OLDEST_FIRST
       - NEWEST_FIRST
+    example: "0"
   enableCreditsMarkerGeneration:
     type: string
     description: >-
@@ -108,6 +110,7 @@ properties:
     x-speakeasy-enums:
       - LIBRARY_DEFAULT
       - DISABLED
+    example: "-1"
   showOrdering:
     type: string
     description: |

--- a/src/models/MetaData.yaml
+++ b/src/models/MetaData.yaml
@@ -72,7 +72,42 @@ properties:
     type: string
     example: Return to Pandora.
   flattenSeasons:
-    $ref: "../models/common/PlexBooleanString.yaml"
+    type: string
+    description: >-
+      Setting that indicates if seasons are set to hidden for the show.
+      (-1 = Library default, 0 = Hide, 1 = Show).
+    enum:
+      - "-1"
+      - "0"
+      - "1"
+    x-speakeasy-enums:
+      - LIBRARY_DEFAULT
+      - HIDE
+      - SHOW
+  episodeSort:
+    type: string
+    description: >-
+      Setting that indicates how episodes are sorted for the show.
+      (-1 = Library default, 0 = Oldest first, 1 = Newest first).
+    enum:
+      - "-1"
+      - "0"
+      - "1"
+    x-speakeasy-enums:
+      - LIBRARY_DEFAULT
+      - OLDEST_FIRST
+      - NEWEST_FIRST
+  enableCreditsMarkerGeneration:
+    type: string
+    description: >-
+      Setting that indicates if credits markers detection is enabled.
+      (-1 = Library default, 0 = Disabled).
+    enum:
+      - "-1"
+      - "0"
+    x-speakeasy-enums:
+      - LIBRARY_DEFAULT
+      - DISABLED
   showOrdering:
     type: string
     description: |


### PR DESCRIPTION
# @coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added configuration options for media library settings:
		- Flatten seasons control with new enumerated values
		- Episode sorting preferences with defined options
		- Credits marker generation toggle with specified values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes # (issue)
https://github.com/LukeHagar/plex-api-spec/issues/77