### PR TITLE
removed subscriptions array from UserPlexAccount

### DIFF
--- a/src/models/UserPlexAccount.yaml
+++ b/src/models/UserPlexAccount.yaml
@@ -33,7 +33,6 @@ required:
   - services
   - subscription
   - subscriptionDescription
-  - subscriptions
   - thumb
   - title
   - twoFactorEnabled


### PR DESCRIPTION
The getTokenDetails() endpoint currently returns a ValidationError result:

`
SDKValidationError: Response validation failed: [
  {
    "code": "invalid_type",
    "expected": "array",
    "received": "undefined",
    "path": [
      "UserPlexAccount",
      "subscriptions"
    ],
    "message": "Required"
  }
]
`

This fix removes the subscriptions array which plex seems to have removed in their API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated user account settings to make subscription details optional, providing greater flexibility in account management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->