### PR TITLE
feat: add endpoints for fetching and uploading posters/artwork

### DIFF
--- a/src/paths/library/metadata/[ratingKey]/arts/get-media-arts.yaml
+++ b/src/paths/library/metadata/[ratingKey]/arts/get-media-arts.yaml
@@ -1,0 +1,64 @@
+tags:
+  - Library
+summary: Get Media Background Artwork
+description: Returns the background artwork for a library item.
+operationId: get-media-arts
+parameters:
+  - name: ratingKey
+    in: path
+    description: the id of the library item to return the artwork of.
+    schema:
+      type: integer
+      example: 16099
+    required: true
+responses:
+  "200":
+    description: The available background artwork for the library item.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            MediaContainer:
+              allOf:
+                - $ref: "../../../../../models/media-container/size.yaml"
+                - $ref: "../../../../../models/media-container/media-tag-version.yaml"
+                - $ref: "../../../../../models/media-container/media-tag-prefix.yaml"
+                - $ref: "../../../../../models/media-container/identifier.yaml"
+                - type: object
+                  required:
+                    - Metadata
+                  properties:
+                    Metadata:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - key
+                          - ratingKey
+                          - selected
+                          - thumb
+                        properties:
+                          key:
+                            type: string
+                            description: The URL of the artwork.
+                            example: https://image.tmdb.org/t/p/original/ixgFmf1X59PUZam2qbAfskx2gQr.jpg
+                          provider:
+                            type: string
+                            description: The provider of the artwork.
+                            example: tmdb
+                          ratingKey:
+                            type: string
+                            description: The URL of the artwork.
+                            example: https://image.tmdb.org/t/p/original/ixgFmf1X59PUZam2qbAfskx2gQr.jpg
+                          selected:
+                            type: boolean
+                            description: Whether this is the selected artwork.
+                            example: true
+                          thumb:
+                            type: string
+                            description: The URL of the artwork thumbnail.
+                            example: https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FixgFmf1X59PUZam2qbAfskx2gQr%2Ejpg
+
+  "404":
+    $ref: "../../../../../responses/404-html.yaml"

--- a/src/paths/library/metadata/[ratingKey]/arts/post-media-arts.yaml
+++ b/src/paths/library/metadata/[ratingKey]/arts/post-media-arts.yaml
@@ -1,0 +1,34 @@
+tags:
+  - Library
+summary: Upload Media Background Artwork
+description: Uploads an image to use as the background artwork for a library item, either from a local file or a remote URL
+operationId: post-media-arts
+parameters:
+  - name: ratingKey
+    in: path
+    description: the id of the library item to return the posters of.
+    schema:
+      type: integer
+      example: 2268
+    required: true
+  - name: url
+    in: query
+    description: The URL of the image, if uploading a remote image
+    schema:
+      type: string
+      example: https://api.mediux.pro/assets/fcfdc487-dd07-4993-a0c1-0a3015362e5b
+    required: false
+requestBody:
+  description: The contents of the image, if uploading a local file
+  content:
+    image/*:
+      schema:
+        type: string
+        format: binary
+
+responses:
+  "200":
+    description: The background artwork was uploaded successfully.
+
+  "404":
+    $ref: "../../../../../responses/404-html.yaml"

--- a/src/paths/library/metadata/[ratingKey]/posters/get-media-posters.yaml
+++ b/src/paths/library/metadata/[ratingKey]/posters/get-media-posters.yaml
@@ -1,0 +1,64 @@
+tags:
+  - Library
+summary: Get Media Posters
+description: Returns the available posters for a library item.
+operationId: get-media-posters
+parameters:
+  - name: ratingKey
+    in: path
+    description: the id of the library item to return the posters of.
+    schema:
+      type: integer
+      example: 16099
+    required: true
+responses:
+  "200":
+    description: The available posters for the library item.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            MediaContainer:
+              allOf:
+                - $ref: "../../../../../models/media-container/size.yaml"
+                - $ref: "../../../../../models/media-container/media-tag-version.yaml"
+                - $ref: "../../../../../models/media-container/media-tag-prefix.yaml"
+                - $ref: "../../../../../models/media-container/identifier.yaml"
+                - type: object
+                  required:
+                    - Metadata
+                  properties:
+                    Metadata:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - key
+                          - ratingKey
+                          - selected
+                          - thumb
+                        properties:
+                          key:
+                            type: string
+                            description: The URL of the poster.
+                            example: https://image.tmdb.org/t/p/original/hntBJjqbv4m0Iyniqaztv9xaudI.jpg
+                          provider:
+                            type: string
+                            description: The provider of the poster.
+                            example: tmdb
+                          ratingKey:
+                            type: string
+                            description: The URL of the poster.
+                            example: https://image.tmdb.org/t/p/original/hntBJjqbv4m0Iyniqaztv9xaudI.jpg
+                          selected:
+                            type: boolean
+                            description: Whether this is the selected poster.
+                            example: true
+                          thumb:
+                            type: string
+                            description: The URL of the poster thumbnail.
+                            example: https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FhntBJjqbv4m0Iyniqaztv9xaudI%2Ejpg
+
+  "404":
+    $ref: "../../../../../responses/404-html.yaml"

--- a/src/paths/library/metadata/[ratingKey]/posters/post-media-poster.yaml
+++ b/src/paths/library/metadata/[ratingKey]/posters/post-media-poster.yaml
@@ -1,0 +1,34 @@
+tags:
+  - Library
+summary: Upload Media Poster
+description: Uploads a poster to a library item, either from a local file or a remote URL
+operationId: post-media-poster
+parameters:
+  - name: ratingKey
+    in: path
+    description: the id of the library item to return the posters of.
+    schema:
+      type: integer
+      example: 2268
+    required: true
+  - name: url
+    in: query
+    description: The URL of the image, if uploading a remote image
+    schema:
+      type: string
+      example: https://api.mediux.pro/assets/fcfdc487-dd07-4993-a0c1-0a3015362e5b
+    required: false
+requestBody:
+  description: The contents of the image, if uploading a local file
+  content:
+    image/*:
+      schema:
+        type: string
+        format: binary
+
+responses:
+  "200":
+    description: The poster was uploaded successfully.
+
+  "404":
+    $ref: "../../../../../responses/404-html.yaml"

--- a/src/pms-spec.yaml
+++ b/src/pms-spec.yaml
@@ -183,8 +183,18 @@ paths:
 
   /library/metadata/{ratingKey}:
     $ref: "./paths/library/metadata/[ratingKey]/get-media-meta-data.yaml"
+  /library/metadata/{ratingKey}/arts:
+    get:
+      $ref: "./paths/library/metadata/[ratingKey]/arts/get-media-arts.yaml"
+    post:
+      $ref: "./paths/library/metadata/[ratingKey]/arts/post-media-arts.yaml"
   /library/metadata/{ratingKey}/banner:
     $ref: "./paths/library/metadata/[ratingKey]/banner/get-banner-image.yaml"
+  /library/metadata/{ratingKey}/posters:
+    get:
+      $ref: "./paths/library/metadata/[ratingKey]/posters/get-media-posters.yaml"
+    post:
+      $ref: "./paths/library/metadata/[ratingKey]/posters/post-media-poster.yaml"
   /library/metadata/{ratingKey}/thumb:
     $ref: "./paths/library/metadata/[ratingKey]/thumb/get-thumb-image.yaml"
   /library/metadata/{ratingKey}/children:

--- a/tests/paths/library/metadata/[ratingKey]/get-media-arts.spec.ts
+++ b/tests/paths/library/metadata/[ratingKey]/get-media-arts.spec.ts
@@ -1,0 +1,572 @@
+import { validateResponseSpec } from "@utils"
+import { describe, it } from "vitest"
+
+describe("GET /library/metadata/[RatingKey]/arts", () => {
+  it("should have a valid spec for a 200 response", () => {
+    const response = {
+      MediaContainer: {
+        Metadata: [
+          {
+            key: "https://image.tmdb.org/t/p/original/ixgFmf1X59PUZam2qbAfskx2gQr.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/ixgFmf1X59PUZam2qbAfskx2gQr.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FixgFmf1X59PUZam2qbAfskx2gQr%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/nNt41AqlnyLMgtiyfiVuS2O8ES9.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/nNt41AqlnyLMgtiyfiVuS2O8ES9.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FnNt41AqlnyLMgtiyfiVuS2O8ES9%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/npD65vPa4vvn1ZHpp3o05A5vdKT.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/npD65vPa4vvn1ZHpp3o05A5vdKT.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FnpD65vPa4vvn1ZHpp3o05A5vdKT%2Ejpg"
+          },
+          {
+            key: "/library/metadata/16099/file?url=metadata%3A%2F%2Fart%2Ftv%2Eplex%2Eagents%2Eseries_23b0f539f808ed931a85685f51fb440e44ed354f",
+            provider: "tmdb",
+            ratingKey: "metadata://art/tv.plex.agents.series_23b0f539f808ed931a85685f51fb440e44ed354f",
+            selected: true,
+            thumb: "/library/metadata/16099/file?url=metadata%3A%2F%2Fart%2Ftv%2Eplex%2Eagents%2Eseries_23b0f539f808ed931a85685f51fb440e44ed354f"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/r9KaBE7i4ovg8uSppQrCp6ZdPD9.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/r9KaBE7i4ovg8uSppQrCp6ZdPD9.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fr9KaBE7i4ovg8uSppQrCp6ZdPD9%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/5OsiT39OiZNdD0v2LiAcI2TpSYj.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/5OsiT39OiZNdD0v2LiAcI2TpSYj.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F5OsiT39OiZNdD0v2LiAcI2TpSYj%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/8hQA04JLNolV9xfvMkaYg3Hg08w.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/8hQA04JLNolV9xfvMkaYg3Hg08w.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F8hQA04JLNolV9xfvMkaYg3Hg08w%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/kcehRTOk6xwmcCqKBbbwB68Eo5z.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/kcehRTOk6xwmcCqKBbbwB68Eo5z.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FkcehRTOk6xwmcCqKBbbwB68Eo5z%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/nFWN7E5n170YN8SdxekuDEv0qTE.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/nFWN7E5n170YN8SdxekuDEv0qTE.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FnFWN7E5n170YN8SdxekuDEv0qTE%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/8TJnaPnSPkjQwwz07UgQcYEggVi.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/8TJnaPnSPkjQwwz07UgQcYEggVi.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F8TJnaPnSPkjQwwz07UgQcYEggVi%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/bs7bXuCCI0cmSNounTs7tynj6wu.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/bs7bXuCCI0cmSNounTs7tynj6wu.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fbs7bXuCCI0cmSNounTs7tynj6wu%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/i0Dtlqn54sSiUhPPNgG8HZy7OoJ.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/i0Dtlqn54sSiUhPPNgG8HZy7OoJ.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fi0Dtlqn54sSiUhPPNgG8HZy7OoJ%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/lCFMJJ7SfjQLMJjkdcy6KOzqgZa.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/lCFMJJ7SfjQLMJjkdcy6KOzqgZa.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FlCFMJJ7SfjQLMJjkdcy6KOzqgZa%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/nUhMmPHnLFr2583Qea2NF8uUQVH.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/nUhMmPHnLFr2583Qea2NF8uUQVH.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FnUhMmPHnLFr2583Qea2NF8uUQVH%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/q0cj4AIOCFb1WS94bu7nfrcgDXY.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/q0cj4AIOCFb1WS94bu7nfrcgDXY.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fq0cj4AIOCFb1WS94bu7nfrcgDXY%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/ecl98P5f0S9rrZjTDHhuz1yEZA3.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/ecl98P5f0S9rrZjTDHhuz1yEZA3.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fecl98P5f0S9rrZjTDHhuz1yEZA3%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/nVooFYJZ7Ncxgz7gAKUop4dULXG.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/nVooFYJZ7Ncxgz7gAKUop4dULXG.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FnVooFYJZ7Ncxgz7gAKUop4dULXG%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/9xDCTGhEWpz206PCiimRGmK67rV.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/9xDCTGhEWpz206PCiimRGmK67rV.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F9xDCTGhEWpz206PCiimRGmK67rV%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/cgJAEz6JDLLVF6tKLo8igRZU5Oy.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/cgJAEz6JDLLVF6tKLo8igRZU5Oy.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FcgJAEz6JDLLVF6tKLo8igRZU5Oy%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/qMyJkIcATHJxTOtjusX9E4hjoPJ.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/qMyJkIcATHJxTOtjusX9E4hjoPJ.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FqMyJkIcATHJxTOtjusX9E4hjoPJ%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/k90HW0I203WXKZIDwt8RXGDYYmV.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/k90HW0I203WXKZIDwt8RXGDYYmV.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fk90HW0I203WXKZIDwt8RXGDYYmV%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/w6LnH9Och1wIaaApD48Q6CqjPCl.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/w6LnH9Och1wIaaApD48Q6CqjPCl.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fw6LnH9Och1wIaaApD48Q6CqjPCl%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/27g2roB8PK9V66eKoL9n9DTUdPL.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/27g2roB8PK9V66eKoL9n9DTUdPL.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F27g2roB8PK9V66eKoL9n9DTUdPL%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/rjAQsvG6d07DXhBi6Gzk06EIIzP.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/rjAQsvG6d07DXhBi6Gzk06EIIzP.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FrjAQsvG6d07DXhBi6Gzk06EIIzP%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/sWzkGeXML9qAHfzSHCxYoamcSeM.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/sWzkGeXML9qAHfzSHCxYoamcSeM.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FsWzkGeXML9qAHfzSHCxYoamcSeM%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/wIXpTihVlolFMHWMi7qrj1gBudP.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/wIXpTihVlolFMHWMi7qrj1gBudP.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FwIXpTihVlolFMHWMi7qrj1gBudP%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/vmnWRlrjdYjxPcq6pLLsQG1bEZ3.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/vmnWRlrjdYjxPcq6pLLsQG1bEZ3.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FvmnWRlrjdYjxPcq6pLLsQG1bEZ3%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/iemgmESTakK5gYmTiZM3p8WIRXv.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/iemgmESTakK5gYmTiZM3p8WIRXv.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FiemgmESTakK5gYmTiZM3p8WIRXv%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/dsMQSCOC9ReOUx0w6E1GMBMeLKS.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/dsMQSCOC9ReOUx0w6E1GMBMeLKS.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FdsMQSCOC9ReOUx0w6E1GMBMeLKS%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/bkYO7aDVkGNBygTGLtwJA97Kif.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/bkYO7aDVkGNBygTGLtwJA97Kif.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FbkYO7aDVkGNBygTGLtwJA97Kif%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/rsKj3i0zBXuTxciUAJg8LgdzdIy.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/rsKj3i0zBXuTxciUAJg8LgdzdIy.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FrsKj3i0zBXuTxciUAJg8LgdzdIy%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/6PjOfFhUETUYhSPP8pxl1s8Fka5.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/6PjOfFhUETUYhSPP8pxl1s8Fka5.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F6PjOfFhUETUYhSPP8pxl1s8Fka5%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/7Kx4BVOFnDsrjhpGtdLccD1oE7r.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/7Kx4BVOFnDsrjhpGtdLccD1oE7r.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F7Kx4BVOFnDsrjhpGtdLccD1oE7r%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/9OYzrmgWduh7ovxs0TizKu4Aw3z.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/9OYzrmgWduh7ovxs0TizKu4Aw3z.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F9OYzrmgWduh7ovxs0TizKu4Aw3z%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/9qL2sbPJPsGBjRRquv7Mvb05v9y.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/9qL2sbPJPsGBjRRquv7Mvb05v9y.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F9qL2sbPJPsGBjRRquv7Mvb05v9y%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/mQYvRc31w26pDsdLOPwJ6YMiuxh.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/mQYvRc31w26pDsdLOPwJ6YMiuxh.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FmQYvRc31w26pDsdLOPwJ6YMiuxh%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/oBGwwDIFg059uNmfxSQywCQQA8Y.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/oBGwwDIFg059uNmfxSQywCQQA8Y.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FoBGwwDIFg059uNmfxSQywCQQA8Y%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/tRuNdLP2DmnHhwJfgF7MVD9dZJD.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/tRuNdLP2DmnHhwJfgF7MVD9dZJD.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FtRuNdLP2DmnHhwJfgF7MVD9dZJD%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/2xTuX7uvouUt2oriSFNAGh55zCX.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/2xTuX7uvouUt2oriSFNAGh55zCX.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F2xTuX7uvouUt2oriSFNAGh55zCX%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/3FsrNUHYwz1qU5x9D7vj4Mfely0.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/3FsrNUHYwz1qU5x9D7vj4Mfely0.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F3FsrNUHYwz1qU5x9D7vj4Mfely0%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/6fvWjcfSYZMsuULueXNMeGFsu34.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/6fvWjcfSYZMsuULueXNMeGFsu34.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F6fvWjcfSYZMsuULueXNMeGFsu34%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/96QoVgLU7AYjIpkidDCwQMxq8DW.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/96QoVgLU7AYjIpkidDCwQMxq8DW.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F96QoVgLU7AYjIpkidDCwQMxq8DW%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/Xap8MtJ8LN9NV9G9bYO7PMafxd.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/Xap8MtJ8LN9NV9G9bYO7PMafxd.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FXap8MtJ8LN9NV9G9bYO7PMafxd%2Ejpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7c62d99.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7c62d99.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7c62d99_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6210954239790.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6210954239790.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6210954239790_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7812467.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7812467.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7812467_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/620f5694e2d68.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/620f5694e2d68.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/620f5694e2d68_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6210951dc1a8f.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6210951dc1a8f.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6210951dc1a8f_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a20fd3a0b1.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a20fd3a0b1.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a20fd3a0b1_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7477c9a.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7477c9a.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/61bdee7477c9a_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/62390314bc257.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/62390314bc257.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/62390314bc257_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6754a61428bd3.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6754a61428bd3.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6754a61428bd3_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a1383d6b23.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a1383d6b23.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a1383d6b23_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/620f529b23056.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/620f529b23056.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/620f529b23056_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6789c64c2459b.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6789c64c2459b.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6789c64c2459b_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a12fded049.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a12fded049.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678a12fded049_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63d2bce8eabf6.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63d2bce8eabf6.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63d2bce8eabf6_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ed770ffb.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ed770ffb.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ed770ffb_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ee939fdf.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ee939fdf.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ee939fdf_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ef717079.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ef717079.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/63de0ef717079_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/64ce618ea8e2a.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/64ce618ea8e2a.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/64ce618ea8e2a_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/675d7650e7990.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/675d7650e7990.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/675d7650e7990_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6781b0ca0ec76.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6781b0ca0ec76.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6781b0ca0ec76_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6789baeab23b2.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6789baeab23b2.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/6789baeab23b2_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678aafe6b8833.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678aafe6b8833.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/678aafe6b8833_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/67c53405106f8.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/67c53405106f8.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/backgrounds/67c53405106f8_t.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvthumb/severance-625081203f8b5.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvthumb/severance-625081203f8b5.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvthumb/severance-625081203f8b5.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-62508194a4755.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-62508194a4755.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/showbackground/severance-62508194a4755.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-678bc71b9762f.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-678bc71b9762f.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/showbackground/severance-678bc71b9762f.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-6250818dc6cb7.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-6250818dc6cb7.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/showbackground/severance-6250818dc6cb7.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-678a95bf8ed1e.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-678a95bf8ed1e.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/showbackground/severance-678a95bf8ed1e.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvthumb/severance-6228ead490205.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvthumb/severance-6228ead490205.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvthumb/severance-6228ead490205.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-678a95bdae96d.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/showbackground/severance-678a95bdae96d.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/showbackground/severance-678a95bdae96d.jpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/6/gracenote/6a2f7f07f2b0e30dcf830f27838d9f58.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/6/gracenote/6a2f7f07f2b0e30dcf830f27838d9f58.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2F6%2Fgracenote%2F6a2f7f07f2b0e30dcf830f27838d9f58%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/a/gracenote/adb0b6b4bf6fb581e37568a647ddb971.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/a/gracenote/adb0b6b4bf6fb581e37568a647ddb971.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2Fa%2Fgracenote%2Fadb0b6b4bf6fb581e37568a647ddb971%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/f/gracenote/ff49ff49bf29cb66ba5ed4bd4492cc69.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/f/gracenote/ff49ff49bf29cb66ba5ed4bd4492cc69.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2Ff%2Fgracenote%2Fff49ff49bf29cb66ba5ed4bd4492cc69%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/6/gracenote/6de9d707b85f4031b309d537ab6647c8.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/6/gracenote/6de9d707b85f4031b309d537ab6647c8.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2F6%2Fgracenote%2F6de9d707b85f4031b309d537ab6647c8%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/d/gracenote/dde72a761b604ca3ab08ff47f8f4cea4.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/d/gracenote/dde72a761b604ca3ab08ff47f8f4cea4.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2Fd%2Fgracenote%2Fdde72a761b604ca3ab08ff47f8f4cea4%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/d/gracenote/d29c4d72c2198239d5165141da59daf3.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/d/gracenote/d29c4d72c2198239d5165141da59daf3.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=270&width=480&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2Fd%2Fgracenote%2Fd29c4d72c2198239d5165141da59daf3%2Ejpg"
+          }
+        ],
+        identifier: "com.plexapp.plugins.library",
+        mediaTagPrefix: "/system/bundle/media/flags/",
+        mediaTagVersion: 1740148659,
+        size: 79
+      }
+    }
+
+    validateResponseSpec("/library/metadata/{ratingKey}/arts", "get", 200, response)
+  })
+})

--- a/tests/paths/library/metadata/[ratingKey]/get-media-posters.spec.ts
+++ b/tests/paths/library/metadata/[ratingKey]/get-media-posters.spec.ts
@@ -1,0 +1,523 @@
+import { validateResponseSpec } from "@utils"
+import { describe, it } from "vitest"
+
+describe("GET /library/metadata/[RatingKey]/posters", () => {
+  it("should have a valid spec for a 200 response", () => {
+    const response = {
+      MediaContainer: {
+        Metadata: [
+          {
+            key: "/library/metadata/16099/file?url=metadata%3A%2F%2Fposters%2Ftv%2Eplex%2Eagents%2Eseries_a2cd5269d40e3c70189b7e7b1143e872570a5eaa",
+            provider: "tmdb",
+            ratingKey: "metadata://posters/tv.plex.agents.series_a2cd5269d40e3c70189b7e7b1143e872570a5eaa",
+            selected: true,
+            thumb: "/library/metadata/16099/file?url=metadata%3A%2F%2Fposters%2Ftv%2Eplex%2Eagents%2Eseries_a2cd5269d40e3c70189b7e7b1143e872570a5eaa"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/hntBJjqbv4m0Iyniqaztv9xaudI.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/hntBJjqbv4m0Iyniqaztv9xaudI.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FhntBJjqbv4m0Iyniqaztv9xaudI%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/lFf6LLrQjYldcZItzOkGmMMigP7.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/lFf6LLrQjYldcZItzOkGmMMigP7.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FlFf6LLrQjYldcZItzOkGmMMigP7%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/Rb7sga832Cyqvafd7CqOzbwdK4.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/Rb7sga832Cyqvafd7CqOzbwdK4.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FRb7sga832Cyqvafd7CqOzbwdK4%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/4z0ywuL3btruvjDaWm5nR86BoR5.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/4z0ywuL3btruvjDaWm5nR86BoR5.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F4z0ywuL3btruvjDaWm5nR86BoR5%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/16x97H9o5q4pfdipsutaNHIylhT.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/16x97H9o5q4pfdipsutaNHIylhT.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F16x97H9o5q4pfdipsutaNHIylhT%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/fEuS3tP97jhE0AnJPv54VUzTmRw.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/fEuS3tP97jhE0AnJPv54VUzTmRw.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FfEuS3tP97jhE0AnJPv54VUzTmRw%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/zoIJh4wTfnoIeKl8qzZRIIrNmKD.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/zoIJh4wTfnoIeKl8qzZRIIrNmKD.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FzoIJh4wTfnoIeKl8qzZRIIrNmKD%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/jKDYNC9cW0bvctV4JNzwkIN6rj6.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/jKDYNC9cW0bvctV4JNzwkIN6rj6.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FjKDYNC9cW0bvctV4JNzwkIN6rj6%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/rDFpBfO70Z8UyXDvmXeGy486NLm.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/rDFpBfO70Z8UyXDvmXeGy486NLm.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FrDFpBfO70Z8UyXDvmXeGy486NLm%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/w5O3VVeG3jIR62IVbNMvFKY0p1Q.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/w5O3VVeG3jIR62IVbNMvFKY0p1Q.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fw5O3VVeG3jIR62IVbNMvFKY0p1Q%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/yMEJr7LBZcwOSR0S3VHa23cmEJ8.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/yMEJr7LBZcwOSR0S3VHa23cmEJ8.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FyMEJr7LBZcwOSR0S3VHa23cmEJ8%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/4Jc2JT1oB1mB0FLhi3axhpdxs6w.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/4Jc2JT1oB1mB0FLhi3axhpdxs6w.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F4Jc2JT1oB1mB0FLhi3axhpdxs6w%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/1yFd096gA4Q0WGlczWTZOSrRgH6.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/1yFd096gA4Q0WGlczWTZOSrRgH6.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F1yFd096gA4Q0WGlczWTZOSrRgH6%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/ywr2xAMFCT3spqdsumRhm9RdWx9.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/ywr2xAMFCT3spqdsumRhm9RdWx9.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fywr2xAMFCT3spqdsumRhm9RdWx9%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/cGX8ELIx2USdm0xBnoqKxCRiAo1.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/cGX8ELIx2USdm0xBnoqKxCRiAo1.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FcGX8ELIx2USdm0xBnoqKxCRiAo1%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/5KzBlAtnc3gcVGhyPzQx8ILPJLu.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/5KzBlAtnc3gcVGhyPzQx8ILPJLu.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F5KzBlAtnc3gcVGhyPzQx8ILPJLu%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/bcu0M7tbUoALuNVM3TdWf9SxMgr.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/bcu0M7tbUoALuNVM3TdWf9SxMgr.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fbcu0M7tbUoALuNVM3TdWf9SxMgr%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/cVeI2AdVWm2MwhEAHGSgUHBzosK.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/cVeI2AdVWm2MwhEAHGSgUHBzosK.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FcVeI2AdVWm2MwhEAHGSgUHBzosK%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/kS9X2otUuFnEh7fwlbf1N9fmGd9.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/kS9X2otUuFnEh7fwlbf1N9fmGd9.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FkS9X2otUuFnEh7fwlbf1N9fmGd9%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/e8fi93S1ZOdne7bJLX0Lqeh9xjp.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/e8fi93S1ZOdne7bJLX0Lqeh9xjp.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fe8fi93S1ZOdne7bJLX0Lqeh9xjp%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/8qIBf4bMIi4nCnfe76IJ8SH8pPt.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/8qIBf4bMIi4nCnfe76IJ8SH8pPt.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F8qIBf4bMIi4nCnfe76IJ8SH8pPt%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/bIvSGN51OCnHJd4rPvudjccN6rj.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/bIvSGN51OCnHJd4rPvudjccN6rj.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FbIvSGN51OCnHJd4rPvudjccN6rj%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/bRVWAMzeS0YO5qAg3GMPLAmCFw5.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/bRVWAMzeS0YO5qAg3GMPLAmCFw5.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FbRVWAMzeS0YO5qAg3GMPLAmCFw5%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/quhj8sxn8tpbXovYB6TAbSUUva9.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/quhj8sxn8tpbXovYB6TAbSUUva9.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fquhj8sxn8tpbXovYB6TAbSUUva9%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/xxDrJdtdMGpnxDBo0UInLVvVXGS.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/xxDrJdtdMGpnxDBo0UInLVvVXGS.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FxxDrJdtdMGpnxDBo0UInLVvVXGS%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/zKgPRcXiJZph1gU4dA7WQLlSbS.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/zKgPRcXiJZph1gU4dA7WQLlSbS.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FzKgPRcXiJZph1gU4dA7WQLlSbS%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/yeHCzn9K7g9NzPUpEmPnGCZyrtd.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/yeHCzn9K7g9NzPUpEmPnGCZyrtd.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FyeHCzn9K7g9NzPUpEmPnGCZyrtd%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/x3B7SjmBSuCiXGwB7JEm1tYDg7m.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/x3B7SjmBSuCiXGwB7JEm1tYDg7m.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fx3B7SjmBSuCiXGwB7JEm1tYDg7m%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/jmDq8z3tI8E1W3vGeNu3OACW0mH.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/jmDq8z3tI8E1W3vGeNu3OACW0mH.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2FjmDq8z3tI8E1W3vGeNu3OACW0mH%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/8DxAqOPaHGVPd9dHCcYU8NBrO7U.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/8DxAqOPaHGVPd9dHCcYU8NBrO7U.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2F8DxAqOPaHGVPd9dHCcYU8NBrO7U%2Ejpg"
+          },
+          {
+            key: "https://image.tmdb.org/t/p/original/g3qlMCAeBZTJvUaA2SKRlTnXiem.jpg",
+            provider: "tmdb",
+            ratingKey: "https://image.tmdb.org/t/p/original/g3qlMCAeBZTJvUaA2SKRlTnXiem.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fimage%2Etmdb%2Eorg%2Ft%2Fp%2Foriginal%2Fg3qlMCAeBZTJvUaA2SKRlTnXiem%2Ejpg"
+          },
+          {
+            key: "https://m.media-amazon.com/images/M/MV5BZDI5YzJhODQtMzQyNy00YWNmLWIxMjUtNDBjNjA5YWRjMzExXkEyXkFqcGc@._V1_.jpg",
+            provider: "imdb",
+            ratingKey: "https://m.media-amazon.com/images/M/MV5BZDI5YzJhODQtMzQyNy00YWNmLWIxMjUtNDBjNjA5YWRjMzExXkEyXkFqcGc@._V1_.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fm%2Emedia-amazon%2Ecom%2Fimages%2FM%2FMV5BZDI5YzJhODQtMzQyNy00YWNmLWIxMjUtNDBjNjA5YWRjMzExXkEyXkFqcGc%40%2E_V1_%2Ejpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/61bc6bbbea3f4.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/61bc6bbbea3f4.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/61bc6bbbea3f4_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/621096b26f0e2.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/621096b26f0e2.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/621096b26f0e2_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6789c55a1aca8.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6789c55a1aca8.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6789c55a1aca8_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/61f96b06c49b1.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/61f96b06c49b1.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/61f96b06c49b1_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6754a1fd5838f.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6754a1fd5838f.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6754a1fd5838f_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67549f903bfa6.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67549f903bfa6.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67549f903bfa6_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/621095a04d1d0.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/621095a04d1d0.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/621095a04d1d0_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c5c20b970.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c5c20b970.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c5c20b970_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c5e9487b9.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c5e9487b9.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c5e9487b9_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c6202f5e9.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c6202f5e9.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6262c6202f5e9_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/64366ef99195f.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/64366ef99195f.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/64366ef99195f_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67660d6a30f05.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67660d6a30f05.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67660d6a30f05_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6789bac7996e4.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6789bac7996e4.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/6789bac7996e4_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/678ab4b256383.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/678ab4b256383.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/678ab4b256383_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3aec3909c5.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3aec3909c5.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3aec3909c5_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3aee647f20.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3aee647f20.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3aee647f20_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3af3484e65.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3af3484e65.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a3af3484e65_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a89473974e2.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a89473974e2.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a89473974e2_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a894a1d5e5e.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a894a1d5e5e.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67a894a1d5e5e_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67ac6c9aa57b2.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67ac6c9aa57b2.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67ac6c9aa57b2_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67b1738977675.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67b1738977675.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67b1738977675_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67c21eb42b776.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67c21eb42b776.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67c21eb42b776_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67cb4645c99fe.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67cb4645c99fe.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67cb4645c99fe_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67e21eefe815a.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67e21eefe815a.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/67e21eefe815a_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/677f0edbe1ef1.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/677f0edbe1ef1.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/677f0edbe1ef1_t.jpg"
+          },
+          {
+            key: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/677f0f54457b9.jpg",
+            provider: "tvdb",
+            ratingKey: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/677f0f54457b9.jpg",
+            selected: false,
+            thumb: "https://artworks.thetvdb.com/banners/v4/series/371980/posters/677f0f54457b9_t.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-6250816dc4374.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-6250816dc4374.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvposter/severance-6250816dc4374.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-678bc7c692456.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-678bc7c692456.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvposter/severance-678bc7c692456.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-67bf38c17586b.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-67bf38c17586b.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvposter/severance-67bf38c17586b.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-67c071ab44d2f.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-67c071ab44d2f.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvposter/severance-67c071ab44d2f.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-62548e5033bec.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-62548e5033bec.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvposter/severance-62548e5033bec.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-67c398f8361f4.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-67c398f8361f4.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvposter/severance-67c398f8361f4.jpg"
+          },
+          {
+            key: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-67c3990c0b654.jpg",
+            provider: "fanarttv",
+            ratingKey: "http://assets.fanart.tv/fanart/tv/371980/tvposter/severance-67c3990c0b654.jpg",
+            selected: false,
+            thumb: "http://assets.fanart.tv/preview/tv/371980/tvposter/severance-67c3990c0b654.jpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/5/gracenote/538df6c08553929c2fbdbd06b48ed722.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/5/gracenote/538df6c08553929c2fbdbd06b48ed722.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2F5%2Fgracenote%2F538df6c08553929c2fbdbd06b48ed722%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/6/gracenote/64b164d9bf22bef2bd4a3e2d916707e2.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/6/gracenote/64b164d9bf22bef2bd4a3e2d916707e2.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2F6%2Fgracenote%2F64b164d9bf22bef2bd4a3e2d916707e2%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/0/gracenote/0a9e41720a2d7d01a644118ff7dd1d9a.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/0/gracenote/0a9e41720a2d7d01a644118ff7dd1d9a.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2F0%2Fgracenote%2F0a9e41720a2d7d01a644118ff7dd1d9a%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/2/gracenote/29a4808993b1acde4670fa06197df83f.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/2/gracenote/29a4808993b1acde4670fa06197df83f.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2F2%2Fgracenote%2F29a4808993b1acde4670fa06197df83f%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/8/gracenote/89190cec9b63f62654f573796f6d7fc7.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/8/gracenote/89190cec9b63f62654f573796f6d7fc7.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2F8%2Fgracenote%2F89190cec9b63f62654f573796f6d7fc7%2Ejpg"
+          },
+          {
+            key: "https://metadata-static.plex.tv/9/gracenote/97b10c42ffd9e4c0c08795249eff56ac.jpg",
+            provider: "gracenote",
+            ratingKey: "https://metadata-static.plex.tv/9/gracenote/97b10c42ffd9e4c0c08795249eff56ac.jpg",
+            selected: false,
+            thumb: "https://images.plex.tv/photo?height=336&width=225&minSize=1&upscale=1&url=https%3A%2F%2Fmetadata-static%2Eplex%2Etv%2F9%2Fgracenote%2F97b10c42ffd9e4c0c08795249eff56ac%2Ejpg"
+          }
+        ],
+        identifier: "com.plexapp.plugins.library",
+        mediaTagPrefix: "/system/bundle/media/flags/",
+        mediaTagVersion: 1740148659,
+        size: 72
+      }
+    }
+
+    validateResponseSpec("/library/metadata/{ratingKey}/posters", "get", 200, response)
+  })
+})


### PR DESCRIPTION
This adds the endpoints for fetching and uploading posters and background artwork to library items.

- `GET /library/metadata/{ratingKey}/arts`
- `POST /library/metadata/{ratingKey}/arts`
- `GET /library/metadata/{ratingKey}/posters`
- `POST /library/metadata/{ratingKey}/posters`

This appears to be the first case where we have multiple methods for the same path and as you can't add multiple references to a path, I elected to stick with 1 file per method and have the method in the root `pms-spec.yaml` file. I'm not attached to this though, so happy to take input on other ways to do this.

Resolves #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced endpoints for retrieving background artwork and media posters for library items.
	- Added options to upload images via file upload or remote URL.
  
- **Tests**
	- Validated response structures for the new endpoints to ensure consistent media management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->