### PR TITLE
Set x-speakeasy-unknown-values for non-boolean enums

### DIFF
--- a/src/models/Friend.yaml
+++ b/src/models/Friend.yaml
@@ -62,6 +62,7 @@ properties:
   status:
     examples:
       - accepted
+    x-speakeasy-unknown-values: allow
     enum:
       - accepted
     description: Current friend request status

--- a/src/models/MetaData.yaml
+++ b/src/models/MetaData.yaml
@@ -76,6 +76,7 @@ properties:
     description: >-
       Setting that indicates if seasons are set to hidden for the show.
       (-1 = Library default, 0 = Hide, 1 = Show).
+    x-speakeasy-unknown-values: allow
     enum:
       - "-1"
       - "0"
@@ -90,6 +91,7 @@ properties:
     description: >-
       Setting that indicates how episodes are sorted for the show.
       (-1 = Library default, 0 = Oldest first, 1 = Newest first).
+    x-speakeasy-unknown-values: allow
     enum:
       - "-1"
       - "0"
@@ -104,6 +106,7 @@ properties:
     description: >-
       Setting that indicates if credits markers detection is enabled.
       (-1 = Library default, 0 = Disabled).
+    x-speakeasy-unknown-values: allow
     enum:
       - "-1"
       - "0"
@@ -120,6 +123,7 @@ properties:
       aired = TheTVDB (Aired),
       dvd = TheTVDB (DVD),
       absolute = TheTVDB (Absolute)).
+    x-speakeasy-unknown-values: allow
     enum:
       - None
       - tmdbAiring
@@ -621,6 +625,7 @@ properties:
           example: "Episode 1"
         type:
           type: string
+          x-speakeasy-unknown-values: allow
           enum:
             - coverPoster
             - background

--- a/src/models/PastSubscription.yaml
+++ b/src/models/PastSubscription.yaml
@@ -70,6 +70,7 @@ properties:
       - "null"
   state:
     example: ended
+    x-speakeasy-unknown-values: allow
     enum:
       - ended
   billing:

--- a/src/models/Subscription.yaml
+++ b/src/models/Subscription.yaml
@@ -125,6 +125,7 @@ properties:
   status:
     description: String representation of subscriptionActive
     example: Inactive
+    x-speakeasy-unknown-values: allow
     enum:
       - Inactive
       - Active

--- a/src/models/UserPlexAccount.yaml
+++ b/src/models/UserPlexAccount.yaml
@@ -141,6 +141,7 @@ properties:
     description: Your current mailing list status (active or unsubscribed)
     type: string
     example: active
+    x-speakeasy-unknown-values: allow
     enum:
       - active
       - unsubscribed
@@ -202,6 +203,7 @@ properties:
             - "null"
         status:
           example: online
+          x-speakeasy-unknown-values: allow
           enum:
             - online
             - offline

--- a/src/models/common/PlexMediaType.yaml
+++ b/src/models/common/PlexMediaType.yaml
@@ -1,4 +1,5 @@
 type: integer
+x-speakeasy-unknown-values: allow
 enum:
   - 1
   - 2

--- a/src/models/common/PlexMediaTypeString.yaml
+++ b/src/models/common/PlexMediaTypeString.yaml
@@ -1,4 +1,5 @@
 type: string
+x-speakeasy-unknown-values: allow
 enum:
   - movie
   - show

--- a/src/models/meta-data/enable-credits-marker-generation.yaml
+++ b/src/models/meta-data/enable-credits-marker-generation.yaml
@@ -7,6 +7,7 @@ properties:
     description: >
       Setting that indicates if credits marker detection is enabled.
       (-1 = Library default, 0 = Disabled).
+    x-speakeasy-unknown-values: allow
     enum:
       - "-1"
       - "0"

--- a/src/models/meta-data/episode-sort.yaml
+++ b/src/models/meta-data/episode-sort.yaml
@@ -7,6 +7,7 @@ properties:
     description: >
       Setting that indicates how episodes are sorted for the show.
       (-1 = Library default, 0 = Oldest first, 1 = Newest first).
+    x-speakeasy-unknown-values: allow
     enum:
       - "-1"
       - "0"

--- a/src/models/meta-data/flatten-seasons.yaml
+++ b/src/models/meta-data/flatten-seasons.yaml
@@ -7,6 +7,7 @@ properties:
     description: >
       Setting that indicates if seasons are set to hidden for the show.
       (-1 = Library default, 0 = Hide, 1 = Show).
+    x-speakeasy-unknown-values: allow
     enum:
       - "-1"
       - "0"

--- a/src/models/meta-data/objects/image.yaml
+++ b/src/models/meta-data/objects/image.yaml
@@ -16,6 +16,7 @@ properties:
           example: "Episode 1"
         type:
           type: string
+          x-speakeasy-unknown-values: allow
           enum:
             - coverPoster
             - background

--- a/src/models/meta-data/show-ordering.yaml
+++ b/src/models/meta-data/show-ordering.yaml
@@ -12,6 +12,7 @@ properties:
         - aired = TheTVDB (Aired)
         - dvd = TheTVDB (DVD)
         - absolute = TheTVDB (Absolute)
+    x-speakeasy-unknown-values: allow
     enum:
       - None
       - tmdbAiring

--- a/src/paths/butler/task.yaml
+++ b/src/paths/butler/task.yaml
@@ -15,6 +15,7 @@ post:
       in: path
       schema:
         type: string
+        x-speakeasy-unknown-values: allow
         enum:
           - BackupDatabase
           - BuildGracenoteCollections
@@ -55,6 +56,7 @@ delete:
       in: path
       schema:
         type: string
+        x-speakeasy-unknown-values: allow
         enum:
           - BackupDatabase
           - BuildGracenoteCollections

--- a/src/paths/colon/timeline.yaml
+++ b/src/paths/colon/timeline.yaml
@@ -27,6 +27,7 @@ get:
       in: query
       schema:
         type: string
+        x-speakeasy-unknown-values: allow
         enum: ["playing", "paused", "stopped"]
       example: "playing"
 

--- a/src/paths/library/[sectionKey]/get-library-items.yaml
+++ b/src/paths/library/[sectionKey]/get-library-items.yaml
@@ -32,6 +32,7 @@ get:
       description: A key representing a specific tag within the section.
       schema:
         type: string
+        x-speakeasy-unknown-values: allow
         enum:
           - unwatched
           - newest

--- a/src/paths/library/[sectionKey]/library-section.yaml
+++ b/src/paths/library/[sectionKey]/library-section.yaml
@@ -5,14 +5,14 @@ get:
   description: |
     ## Library Details Endpoint
 
-    This endpoint provides comprehensive details about the library, focusing on organizational aspects rather than the content itself.   
+    This endpoint provides comprehensive details about the library, focusing on organizational aspects rather than the content itself.
 
     The details include:
 
     ### Directories
     Organized into three categories:
 
-    - **Primary Directories**: 
+    - **Primary Directories**:
       - Used in some clients for quick access to media subsets (e.g., "All", "On Deck").
       - Most can be replicated via media queries.
       - Customizable by users.
@@ -47,7 +47,7 @@ get:
   parameters:
     - name: includeDetails
       description: |
-        Whether or not to include details for a section (types, filters, and sorts). 
+        Whether or not to include details for a section (types, filters, and sorts).
         Only exists for backwards compatibility, media providers other than the server libraries have it on always.
       in: query
       schema:

--- a/src/paths/library/get-search-all-libraries.yaml
+++ b/src/paths/library/get-search-all-libraries.yaml
@@ -21,6 +21,7 @@ get:
         type: array
         items:
           type: string
+          x-speakeasy-unknown-values: allow
           enum:
             - movies
             - music

--- a/src/paths/library/sections/watchlist/get-watch-list.yaml
+++ b/src/paths/library/sections/watchlist/get-watch-list.yaml
@@ -16,6 +16,7 @@ get:
       required: true
       schema:
         type: string
+        x-speakeasy-unknown-values: allow
         enum:
           - all
           - available
@@ -36,6 +37,7 @@ get:
       required: false
       schema:
         type: string
+        x-speakeasy-unknown-values: allow
         enum:
           - movie
           - show

--- a/src/paths/logs/log.yaml
+++ b/src/paths/logs/log.yaml
@@ -8,15 +8,16 @@ get:
   parameters:
     - name: level
       description: |
-        An integer log level to write to the PMS log with.  
-        0: Error  
-        1: Warning  
-        2: Info  
-        3: Debug  
+        An integer log level to write to the PMS log with.
+        0: Error
+        1: Warning
+        2: Info
+        3: Debug
         4: Verbose
       in: query
       schema:
         type: integer
+        x-speakeasy-unknown-values: allow
         enum:
           - 0
           - 1
@@ -52,13 +53,13 @@ post:
     - Log
   summary: Logging a multi-line message
   description: |
-    This endpoint allows for the batch addition of log entries to the main Plex Media Server log.  
-    It accepts a text/plain request body, where each line represents a distinct log entry.  
-    Each log entry consists of URL-encoded key-value pairs, specifying log attributes such as 'level', 'message', and 'source'.  
+    This endpoint allows for the batch addition of log entries to the main Plex Media Server log.
+    It accepts a text/plain request body, where each line represents a distinct log entry.
+    Each log entry consists of URL-encoded key-value pairs, specifying log attributes such as 'level', 'message', and 'source'.
 
-    Log entries are separated by a newline character (`\n`).  
-    Each entry's parameters should be URL-encoded to ensure accurate parsing and handling of special characters.  
-    This method is efficient for logging multiple entries in a single API call, reducing the overhead of multiple individual requests.  
+    Log entries are separated by a newline character (`\n`).
+    Each entry's parameters should be URL-encoded to ensure accurate parsing and handling of special characters.
+    This method is efficient for logging multiple entries in a single API call, reducing the overhead of multiple individual requests.
 
     The 'level' parameter specifies the log entry's severity or importance, with the following integer values:
     - `0`: Error - Critical issues that require immediate attention.

--- a/src/paths/playlists/playlists.yaml
+++ b/src/paths/playlists/playlists.yaml
@@ -19,6 +19,7 @@ post:
       in: query
       schema:
         type: string
+        x-speakeasy-unknown-values: allow
         enum:
           - audio
           - video
@@ -137,6 +138,7 @@ get:
       in: query
       schema:
         type: string
+        x-speakeasy-unknown-values: allow
         enum:
           - audio
           - video
@@ -147,6 +149,7 @@ get:
       in: query
       schema:
         type: integer
+        x-speakeasy-unknown-values: allow
         enum:
           - 0
           - 1

--- a/src/paths/playlists/upload.yaml
+++ b/src/paths/playlists/upload.yaml
@@ -8,11 +8,11 @@ post:
   parameters:
     - name: path
       description: |
-        absolute path to a directory on the server where m3u files are stored, or the absolute path to a playlist file on the server. 
-        If the `path` argument is a directory, that path will be scanned for playlist files to be processed. 
-        Each file in that directory creates a separate playlist, with a name based on the filename of the file that created it. 
-        The GUID of each playlist is based on the filename. 
-        If the `path` argument is a file, that file will be used to create a new playlist, with the name based on the filename of the file that created it. 
+        absolute path to a directory on the server where m3u files are stored, or the absolute path to a playlist file on the server.
+        If the `path` argument is a directory, that path will be scanned for playlist files to be processed.
+        Each file in that directory creates a separate playlist, with a name based on the filename of the file that created it.
+        The GUID of each playlist is based on the filename.
+        If the `path` argument is a file, that file will be used to create a new playlist, with the name based on the filename of the file that created it.
         The GUID of each playlist is based on the filename.
       in: query
       schema:
@@ -21,9 +21,9 @@ post:
       required: true
     - name: force
       description: |
-        Force overwriting of duplicate playlists.  
-        By default, a playlist file uploaded with the same path will overwrite the existing playlist. 
-        The `force` argument is used to disable overwriting.  
+        Force overwriting of duplicate playlists.
+        By default, a playlist file uploaded with the same path will overwrite the existing playlist.
+        The `force` argument is used to disable overwriting.
         If the `force` argument is set to 0, a new playlist will be created suffixed with the date and time that the duplicate was uploaded.
       in: query
       schema:

--- a/src/pms-spec.yaml
+++ b/src/pms-spec.yaml
@@ -330,9 +330,9 @@ tags:
       Hubs are a structured two-dimensional container for media, generally represented by multiple horizontal rows.
   - name: Playlists
     description: |
-      Playlists are ordered collections of media. They can be dumb (just a list of media) or smart (based on a media query, such as "all albums from 2017"). 
+      Playlists are ordered collections of media. They can be dumb (just a list of media) or smart (based on a media query, such as "all albums from 2017").
       They can be organized in (optionally nesting) folders.
-      Retrieving a playlist, or its items, will trigger a refresh of its metadata. 
+      Retrieving a playlist, or its items, will trigger a refresh of its metadata.
       This may cause the duration and number of items to change.
   - name: Search
     description: |


### PR DESCRIPTION
Speakeasy generates "closed enums" by default, which doesn't work well for forward compatibility, meaning that when Plex updates their API and the response types include a new type of value, it can result in errors when unmarshaling the response in one of the generated SDKs.

To resolve this, they support using "open enums" by specifying the x-speakeasy-unknown-values on the schema for an enum.

For details see For details see https://www.speakeasy.com/docs/customize/data-model/enums#open-vs-closed-enums

I've only does this for non-boolean enums, ie: enums where the values aren't generally 0 or 1 for the purposes of true/false.

I also did this for non-model schemas (paths) too. This allows users of the SDK to manually provide a value for an unsupported enum in their request parameters. This is useful when the SDK hasn't been updated to support a new value available for filtering for example.

Fixes https://github.com/LukeHagar/plex-api-spec/issues/95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Relaxed validation for various fields and parameters across the app and API, allowing unknown or additional values beyond the predefined options in dropdowns, filters, and status indicators.

- **Style**
  - Removed unnecessary trailing spaces and improved whitespace in several descriptions to enhance readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->