### PR TITLE
Update watchlist server URL to discover.provider.plex.tv

### DIFF
--- a/output/plex-media-server-spec-dereferenced.yaml
+++ b/output/plex-media-server-spec-dereferenced.yaml
@@ -5676,8 +5676,8 @@ paths:
                           example: 401
   '/library/sections/watchlist/{filter}':
     servers:
-      - url: 'https://metadata.provider.plex.tv'
-        description: The plex metadata provider server
+      - url: 'https://discover.provider.plex.tv'
+        description: The plex discover provider server
     get:
       tags:
         - Watchlist

--- a/src/paths/library/sections/watchlist/get-watch-list.yaml
+++ b/src/paths/library/sections/watchlist/get-watch-list.yaml
@@ -1,6 +1,6 @@
 servers:
-  - url: "https://metadata.provider.plex.tv"
-    description: The plex metadata provider server
+  - url: "https://discover.provider.plex.tv"
+    description: The plex discover provider server
 get:
   tags:
     - Watchlist


### PR DESCRIPTION
Plex changed the URL for accessing a watchlist from `metadata.provider.plex.tv` to `discover.provider.plex.tv`, leading to a 404 status code when using this SDK to pull the watchlist.

This change was also made recently in `python-plexapi`: https://github.com/pushingkarmaorg/python-plexapi/pull/1544

I didn't see anything else that needed to be updated to accommodate this change, but I certainly could have missed something.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Changes
  - The /library/sections/watchlist/{filter} endpoint now uses the discover provider server.
- Documentation
  - Updated endpoint description to reflect the discover provider.
- Chores
  - Synced API specification to point the watchlist endpoint to https://discover.provider.plex.tv instead of https://metadata.provider.plex.tv.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->