### PR TITLE
fix: optimizedForStreaming is an integer

### DIFF
--- a/plex-api-spec.yaml
+++ b/plex-api-spec.yaml
@@ -14779,8 +14779,11 @@ components:
           format: int64
           example: 1
         optimizedForStreaming:
-          type: boolean
-          example: false
+          type: integer
+          format: int32
+          enum:
+            - 0
+            - 1
         Part:
           type: array
           items:


### PR DESCRIPTION
`GetLibraryItems` fails for me for multiple library items due to `optimizedForStreaming` being an integer instead of a boolean. I've also tried updating Plex to the latest version, but it didn't help.

This quick fix works for me: https://github.com/LukasParke/plexgo/compare/main...deanrock:plexgo:main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Updated the media streaming optimization flag format in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->